### PR TITLE
TRIPLEX-616: Tooltip. Замечания

### DIFF
--- a/src/components/TabsLine/components/TabsLineDropdown.tsx
+++ b/src/components/TabsLine/components/TabsLineDropdown.tsx
@@ -3,7 +3,7 @@ import clsx from "clsx";
 import { TestProps } from "../../../types/CoreTypes";
 import { Dropdown } from "../../Dropdown";
 import { DropdownList } from "../../Dropdown/desktop/DropdownList";
-import CaretdownStrokeSrvIcon16 from "@sberbusiness/icons-next/CaretdownStrokeSrvIcon16";
+import { CaretdownStrokeSrvIcon16 } from "@sberbusiness/icons-next";
 import { isKey } from "../../../utils/keyboard";
 import { DropdownListContext } from "../../Dropdown/DropdownListContext";
 import { uniqueId } from "lodash-es";

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,2 +1,3 @@
-export * from "@sberbusiness/triplex-next/components/Tooltip/Tooltip";
-export { ETooltipPreferPlace, ETooltipSize } from "@sberbusiness/triplex-next/components/Tooltip/enums";
+export { Tooltip } from "./Tooltip";
+export { ETooltipPreferPlace, ETooltipSize } from "./enums";
+export type { ITooltipProps, ITooltipDesktopProps } from "./types";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -45,3 +45,4 @@ export * from "./SelectField";
 export * from "./OrderedList";
 export * from "./UnorderedList";
 export * from "./SuggestField";
+export * from "./Tooltip";

--- a/stories/release-notes/v1/1.3.0.mdx
+++ b/stories/release-notes/v1/1.3.0.mdx
@@ -6,9 +6,13 @@ import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
 
 <Heading>Изменения</Heading>
 
-**ComponentTitle**
+**Tooltip**
 
-- Description.
+- Исправлен экспорт компонента и необходимых enum-ов через общий индексный файл.
+
+**TabsLineDropdown**
+
+- Исправлен импорт иконки на индексный
 
 <Heading>Новые компоненты</Heading>
 


### PR DESCRIPTION
- исправлен экспорт Tooltip в индексном файле
- исправлен импорт иконки в TabsLineDropdown (при подключении собранной библиотеки через file: не может отрезолвить полный путь, требует расширение файла)