### PR TITLE
TRIPLEX-737 Пофиксил баг с паддингами TagColor для размеров sm и md

### DIFF
--- a/src/components/TagColor/styles/TagColor.module.less
+++ b/src/components/TagColor/styles/TagColor.module.less
@@ -7,7 +7,7 @@
 
     &.sm {
         height: 16px;
-        padding: 2px 6px 3px 6px;
+        padding: 2px 6px;
         border-radius: 4px;
 
         font-size: 10px;
@@ -16,7 +16,7 @@
 
     &.md {
         height: 20px;
-        padding: 2px 8px 3px 8px;
+        padding: 2px 8px;
         border-radius: 4px;
 
         font-size: 12px;


### PR DESCRIPTION
<img width="1510" height="820" alt="Снимок экрана 2025-12-30 в 12 46 11" src="https://github.com/user-attachments/assets/1f423b91-6f47-4ec4-a445-609f670041dd" />
<img width="1510" height="820" alt="Снимок экрана 2025-12-30 в 12 46 21" src="https://github.com/user-attachments/assets/858b4f51-902f-45a6-a6cf-276083d7f60c" />
