### PR TITLE
TRIPLEX-752 TextField Исправлено отображение крестика

### DIFF
--- a/src/components/FormField/components/FormFieldClear.tsx
+++ b/src/components/FormField/components/FormFieldClear.tsx
@@ -14,12 +14,12 @@ export interface IFormFieldClearProps extends React.ButtonHTMLAttributes<HTMLBut
 /** Кнопка очищения введенного значения. */
 export const FormFieldClear = React.forwardRef<HTMLButtonElement, IFormFieldClearProps>(
     ({ className, onMouseDown, ...htmlClearAttributes }, ref) => {
-        const { status, valueExist } = useContext(FormFieldContext);
+        const { status, focused, hovered, valueExist } = useContext(FormFieldContext);
         const classNames = clsx(
             styles.formFieldClear,
             "hoverable",
             {
-                [styles.hidden]: !valueExist || status === EFormFieldStatus.DISABLED,
+                [styles.hidden]: !valueExist || status === EFormFieldStatus.DISABLED || !(focused || hovered),
             },
             className,
         );

--- a/stories/release-notes/v1/1.14.0.mdx
+++ b/stories/release-notes/v1/1.14.0.mdx
@@ -12,6 +12,6 @@ import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
 
 <Heading>Изменения</Heading>
 
-**ComponentTitle**
+**FormFieldClear**
 
-- Description.
+- Исправлена логика отображения: кнопка очистки появляется при наличии значения только в состояниях hover, active, focus.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Примечания к выпуску

* **Улучшения**
  * Кнопка очистки в полях ввода теперь отображается при наведении, фокусе или активном состоянии поля.

* **Документация**
  * Обновлены примечания к выпуску с уточнением поведения кнопки очистки.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->