### PR TITLE
TRIPLEX-762 FooterPage shadow

### DIFF
--- a/src/components/Page/styles/Page.module.less
+++ b/src/components/Page/styles/Page.module.less
@@ -48,7 +48,7 @@
         border-bottom-right-radius: var(--r-bottom, @page-island-border-radius) !important;
     
         &[data-stuck="true"] {
-            box-shadow: var(--triplex-next-HeaderPage-StickyShadow) !important;
+            box-shadow: var(--triplex-next-FooterPage-StickyShadow) !important;
         }
     }
 }

--- a/stories/release-notes/v1/1.16.0.mdx
+++ b/stories/release-notes/v1/1.16.0.mdx
@@ -16,6 +16,10 @@ import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
 
 – Исправлен баг с передачей postfix.
 
+**FooterPage**
+
+- Исправлена тень, когда Footer имеет прилипает к нижней части экрана.
+
 **HelpBox**
 
 – Добавлено свойство iconProps для изменения цвета иконки.

--- a/stories/release-notes/v1/1.16.0.mdx
+++ b/stories/release-notes/v1/1.16.0.mdx
@@ -18,7 +18,7 @@ import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
 
 **FooterPage**
 
-- Исправлена тень, когда Footer имеет прилипает к нижней части экрана.
+- Исправлена тень, когда Footer прилипает к нижней части экрана.
 
 **HelpBox**
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления ошибок**
  * Исправлено отображение теневого эффекта нижнего колонтитула при закреплении страницы: тень теперь корректно применяется, когда нижний колонтитул фиксируется у нижней части экрана.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->