### PR TITLE
Triplex 763 Side overlay close button fixed and export types

### DIFF
--- a/src/components/CheckboxTree/index.ts
+++ b/src/components/CheckboxTree/index.ts
@@ -1,1 +1,2 @@
 export * from "./CheckboxTree";
+export * from "./types";

--- a/src/components/FormField/index.ts
+++ b/src/components/FormField/index.ts
@@ -10,3 +10,4 @@ export * from "./components/FormFieldPostfix";
 export * from "./components/FormFieldPrefix";
 export * from "./components/FormFieldTextarea";
 export * from "./enums";
+export * from "./types";

--- a/src/components/LightBox/LightBoxSideOverlay/LightBoxSideOverlayCloseDesktop.tsx
+++ b/src/components/LightBox/LightBoxSideOverlay/LightBoxSideOverlayCloseDesktop.tsx
@@ -39,14 +39,18 @@ export const LightBoxSideOverlayCloseDesktop: React.FC<ILightBoxSideOverlayClose
         />
     );
 
-    if (clickByEsc) {
-        return (
-            <TriggerClickOnKeyDownEvent eventKeyCode={EVENT_KEY_CODES.ESCAPE} targetRef={ref}>
-                {renderButton()}
-            </TriggerClickOnKeyDownEvent>
-        );
-    }
-    return renderButton();
+    const renderContent = () => {
+        if (clickByEsc) {
+            return (
+                <TriggerClickOnKeyDownEvent eventKeyCode={EVENT_KEY_CODES.ESCAPE} targetRef={ref}>
+                    {renderButton()}
+                </TriggerClickOnKeyDownEvent>
+            );
+        }
+        return renderButton();
+    };
+
+    return <div className={styles.lightBoxSideOverlayCloseDesktopContainer}>{renderContent()}</div>;
 };
 
 LightBoxSideOverlayCloseDesktop.displayName = "LightBoxSideOverlayCloseDesktop";

--- a/src/components/LightBox/LightBoxSideOverlay/styles/LightBoxSideOverlayClose.module.less
+++ b/src/components/LightBox/LightBoxSideOverlay/styles/LightBoxSideOverlayClose.module.less
@@ -1,9 +1,17 @@
 @import 'src/styles/style';
 
-.lightBoxSideOverlayCloseDesktop {
+.lightBoxSideOverlayCloseDesktopContainer {
     position: absolute;
     top: 24px;
     right: 24px;
+    bottom: 0;
+    pointer-events: none;
+}
+
+.lightBoxSideOverlayCloseDesktop {
+    position: sticky;
+    top: 24px;
+    pointer-events: auto;
 }
 
 .lightBoxSideOverlayCloseMobile {
@@ -15,7 +23,7 @@
 
 /** Breakpoint для экранов менее 1024px. */
 .global-LB-less-or-equal-media-point-0 {
-    .lightBoxSideOverlayCloseDesktop {
+    .lightBoxSideOverlayCloseDesktopContainer {
         display: none;
     }
 
@@ -33,7 +41,7 @@
 
 /** Breakpoint для экранов шире 1024px. */
 .global-LB-more-media-point-0 {
-    .lightBoxSideOverlayCloseDesktop {
+    .lightBoxSideOverlayCloseDesktopContainer {
         display: block;
     }
     

--- a/src/components/ModalWindow/components/ModalWindowClose.tsx
+++ b/src/components/ModalWindow/components/ModalWindowClose.tsx
@@ -11,7 +11,7 @@ import styles from "../styles/ModalWindowClose.module.less";
 /**
  * Свойства компонента кнопки закрытия модального окна.
  */
-interface IModalWindowCloseProps extends Omit<IButtonSecondaryProps, "size" | "theme" | "icon"> {}
+export interface IModalWindowCloseProps extends Omit<IButtonSecondaryProps, "size" | "theme" | "icon"> {}
 
 /**
  * Компонент кнопки закрытия модального окна.

--- a/src/components/ModalWindow/components/ModalWindowClose.tsx
+++ b/src/components/ModalWindow/components/ModalWindowClose.tsx
@@ -11,7 +11,7 @@ import styles from "../styles/ModalWindowClose.module.less";
 /**
  * Свойства компонента кнопки закрытия модального окна.
  */
-interface IModalWindowCloseProps extends IButtonSecondaryProps {}
+interface IModalWindowCloseProps extends Omit<IButtonSecondaryProps, "size" | "theme" | "icon"> {}
 
 /**
  * Компонент кнопки закрытия модального окна.

--- a/stories/release-notes/v1/1.20.0.mdx
+++ b/stories/release-notes/v1/1.20.0.mdx
@@ -9,3 +9,7 @@ import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
 **IslandAccordion**
 
 - Исправлен размер Title в размере MD.
+
+**LightBox.SideOverlay**
+
+- Кнопка закрытия SideOverlay теперь фиксирована при скролле.

--- a/stories/release-notes/v1/1.20.0.mdx
+++ b/stories/release-notes/v1/1.20.0.mdx
@@ -24,4 +24,4 @@ import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
 
 **ModalWindow**
 
-- В `ModalWindowClose` исключены  пропсы `size`, `theme` и `icon`.
+- В `ModalWindowClose` исключены пропсы `size`, `theme` и `icon`.

--- a/stories/release-notes/v1/1.20.0.mdx
+++ b/stories/release-notes/v1/1.20.0.mdx
@@ -13,3 +13,15 @@ import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
 **LightBox.SideOverlay**
 
 - Кнопка закрытия SideOverlay теперь фиксирована при скролле.
+
+**CheckboxTree**
+
+- Добавлен экспорт `ICheckboxTreeCheckboxData`.
+
+**MaskedField**
+
+- Добавлен экспорт `TFormFieldMaskedInputMask`.
+
+**ModalWindow**
+
+- В `ModalWindowClose` исключены  пропсы `size`, `theme` и `icon`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CheckboxTree, FormField и MaskedField теперь экспортируют дополнительные типы для публичного использования.

* **Improvements**
  * Кнопка закрытия в LightBox.SideOverlay фиксируется при прокрутке (поведение прокрутки улучшено).

* **Breaking Changes**
  * ModalWindowClose больше не позволяет переопределять свойства size, theme и icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->