### PR TITLE
TRIPLEX-731 ChipMultiselect Доработки

### DIFF
--- a/src/components/CheckboxTreeExtended/styles/CheckboxTreeExtended.module.less
+++ b/src/components/CheckboxTreeExtended/styles/CheckboxTreeExtended.module.less
@@ -3,7 +3,6 @@
 .checkboxTreeExtended {
     // Компенсация отступа последней ноды.
     margin-bottom: -12px;
-    padding: 12px;
 }
 
 .checkboxTreeExtendedNode {

--- a/src/components/MultiselectField/components/MultiselectFieldDropdownContent.tsx
+++ b/src/components/MultiselectField/components/MultiselectFieldDropdownContent.tsx
@@ -21,11 +21,13 @@ export const MultiselectFieldDropdownContent: React.FC<IMultiselectFieldDropdown
     const { size } = useContext(MultiselectFieldContext);
 
     return (
-        <div className={clsx(styles.multiselectFieldContentWrapper, className)} {...htmlDivAttributes}>
-            <div tabIndex={-1} className={clsx(styles.multiselectFieldContent, sizeToClassNameMap[size])}>
-                {children}
-                {loading && <LoaderScreen type="small" className={styles.loaderScreen} />}
-            </div>
+        <div
+            tabIndex={-1}
+            className={clsx(styles.multiselectFieldContent, sizeToClassNameMap[size], className)}
+            {...htmlDivAttributes}
+        >
+            {children}
+            {loading && <LoaderScreen type="small" className={styles.loaderScreen} />}
         </div>
     );
 };

--- a/src/components/MultiselectField/styles/MultiselectFieldDropdownContent.module.less
+++ b/src/components/MultiselectField/styles/MultiselectFieldDropdownContent.module.less
@@ -1,25 +1,27 @@
-.multiselectFieldContentWrapper {
-    .multiselectFieldContent {
-        position: relative;
-        padding-bottom: 12px;
-        box-sizing: border-box;
-        overflow-y: auto;
-        outline: none;
+.multiselectFieldContent {
+    position: relative;
+    padding: 0 12px 12px 12px;
+    box-sizing: border-box;
+    overflow-y: auto;
+    outline: none;
 
-        &:has(.loaderScreen) {
-            overflow: hidden;
-        }
+    &:first-child {
+        padding-top: 12px;
+    }
 
-        &.sm {
-            max-height: 208px;
-        }
+    &:has(.loaderScreen) {
+        overflow: hidden;
+    }
 
-        &.md {
-            max-height: 266px;
-        }
+    &.sm {
+        max-height: 208px;
+    }
 
-        &.lg {
-            max-height: 296px;
-        }
+    &.md {
+        max-height: 266px;
+    }
+
+    &.lg {
+        max-height: 296px;
     }
 }

--- a/src/components/MultiselectField/styles/MultiselectFieldDropdownHeader.module.less
+++ b/src/components/MultiselectField/styles/MultiselectFieldDropdownHeader.module.less
@@ -1,3 +1,3 @@
 .multiselectFieldHeader {
-    padding: 12px 12px 0 12px;
+    padding: 12px;
 }

--- a/stories/Chips/ChipMultiselect.stories.tsx
+++ b/stories/Chips/ChipMultiselect.stories.tsx
@@ -306,10 +306,18 @@ export const Playground: StoryObj<typeof ChipMultiselect> = {
                         {renderDropdownContent()}
                     </MultiselectField.Dropdown.Content>
                     <MultiselectField.Dropdown.Footer>
-                        <Button theme={EButtonTheme.GENERAL} size={EComponentSize.SM} onClick={() => setOpened(false)}>
+                        <Button
+                            theme={EButtonTheme.SECONDARY}
+                            size={args.size === EComponentSize.LG ? EComponentSize.MD : EComponentSize.SM}
+                            onClick={() => setOpened(false)}
+                        >
                             Button text
                         </Button>
-                        <Button theme={EButtonTheme.LINK} size={EComponentSize.SM} onClick={handleClickClearFilter}>
+                        <Button
+                            theme={EButtonTheme.LINK}
+                            size={args.size === EComponentSize.LG ? EComponentSize.MD : EComponentSize.SM}
+                            onClick={handleClickClearFilter}
+                        >
                             Button link text
                         </Button>
                     </MultiselectField.Dropdown.Footer>
@@ -544,7 +552,7 @@ export const Default: StoryObj<typeof ChipMultiselect> = {
                 </MultiselectField.Dropdown.Header>
                 <MultiselectField.Dropdown.Content>{renderDropdownContent()}</MultiselectField.Dropdown.Content>
                 <MultiselectField.Dropdown.Footer>
-                    <Button theme={EButtonTheme.GENERAL} size={EComponentSize.SM} onClick={() => setOpened(false)}>
+                    <Button theme={EButtonTheme.SECONDARY} size={EComponentSize.SM} onClick={() => setOpened(false)}>
                         Button text
                     </Button>
                     <Button theme={EButtonTheme.LINK} size={EComponentSize.SM} onClick={handleClickClearFilter}>
@@ -772,10 +780,18 @@ export const Sizes: StoryObj<typeof ChipMultiselect> = {
                     </MultiselectField.Dropdown.Header>
                     <MultiselectField.Dropdown.Content>{renderDropdownContent()}</MultiselectField.Dropdown.Content>
                     <MultiselectField.Dropdown.Footer>
-                        <Button theme={EButtonTheme.GENERAL} size={EComponentSize.SM} onClick={() => setOpened(false)}>
+                        <Button
+                            theme={EButtonTheme.SECONDARY}
+                            size={args.size === EComponentSize.LG ? EComponentSize.MD : EComponentSize.SM}
+                            onClick={() => setOpened(false)}
+                        >
                             Button text
                         </Button>
-                        <Button theme={EButtonTheme.LINK} size={EComponentSize.SM} onClick={handleClickClearFilter}>
+                        <Button
+                            theme={EButtonTheme.LINK}
+                            size={args.size === EComponentSize.LG ? EComponentSize.MD : EComponentSize.SM}
+                            onClick={handleClickClearFilter}
+                        >
                             Button link text
                         </Button>
                     </MultiselectField.Dropdown.Footer>
@@ -1031,7 +1047,7 @@ export const Loading: StoryObj<typeof ChipMultiselect> = {
                     {renderDropdownContent()}
                 </MultiselectField.Dropdown.Content>
                 <MultiselectField.Dropdown.Footer>
-                    <Button theme={EButtonTheme.GENERAL} size={EComponentSize.SM} onClick={() => setOpened(false)}>
+                    <Button theme={EButtonTheme.SECONDARY} size={EComponentSize.SM} onClick={() => setOpened(false)}>
                         Button text
                     </Button>
                     <Button theme={EButtonTheme.LINK} size={EComponentSize.SM} onClick={handleClickClearFilter}>

--- a/stories/release-notes/v1/1.22.0.mdx
+++ b/stories/release-notes/v1/1.22.0.mdx
@@ -7,3 +7,12 @@ import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
 <Heading>Изменения</Heading>
 
 - Пакет `react-window` убран из зависимостей.
+
+**CheckboxTreeExtended**
+
+- Удалены отступы.
+
+**MultiselectField**
+
+- Для `MultiselectFieldDropdownContent` добавлены горизонтальные отступы, а также верхний отступ (если не используется `MultiselectFieldDropdownHeader`);
+- Для `MultiselectFieldDropdownHeader` добавлен нижний отступ.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Убраны базовые внутренние отступы у CheckboxTreeExtended (остался отступ в мобильной версии).
  * Заголовок dropdown MultiselectField теперь с единым padding 12px; контент dropdown получил горизонтальные отступы, скорректированы верхние/нижние отступы и упрощена DOM‑структура.

* **Tests**
  * Обновлены истории ChipMultiselect: кнопки переключены на тему Secondary; размер кнопок стал условным в некоторых историях.

* **Documentation**
  * Релиз‑ноты дополнены заметками по изменениям в CheckboxTreeExtended и MultiselectField.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->