### PR TITLE
TRIPLEX-844 HelpBox: AI-Ready

### DIFF
--- a/docs/ai/ROADMAP.md
+++ b/docs/ai/ROADMAP.md
@@ -56,6 +56,7 @@
 | Компонент | AI.md | Figma Node | Статус |
 |---|---|---|---|
 | Button | ✅ | ✅ | Пилот |
+| HelpBox | ✅ | ⬜ | AI-Ready |
 | Alert | ⬜ | ⬜ | — |
 | Badge | ⬜ | ⬜ | — |
 | Card | ⬜ | ⬜ | — |

--- a/src/components/HelpBox/HelpBox-AI.md
+++ b/src/components/HelpBox/HelpBox-AI.md
@@ -1,0 +1,153 @@
+---
+component: HelpBox
+category: HelpBox
+figma-node: ""
+figma-file: ""
+related: [Tooltip, ButtonIcon, MobileView, FocusTrap]
+tokens: []
+stories: stories/HelpBox/HelpBox.stories.tsx
+version: "1.0"
+---
+
+# HelpBox
+
+## Назначение
+
+Иконка "?" (`QuestioncircleFilledSrvIcon16`) с всплывающей подсказкой (Tooltip).
+Объединяет ButtonIcon-триггер, Tooltip и FocusTrap в одном компоненте.
+
+Используй когда: нужна контекстная подсказка рядом с элементом интерфейса.
+Не используй когда: нужен полноценный попап с формой или сложным контентом — используй Dropdown или Modal.
+
+---
+
+## Файловая структура
+
+```text
+src/components/HelpBox/
+├── HelpBox.tsx                   # Основной компонент
+├── index.ts                      # Barrel export
+├── styles/
+│   └── HelpBox.module.less       # Минимальные стили (position, vertical-align)
+└── __tests__/
+    └── HelpBox.test.tsx          # Unit-тесты
+```
+
+---
+
+## Варианты и props
+
+### Обязательные props
+
+| Prop | Тип | Описание |
+|---|---|---|
+| `tooltipSize` | `ETooltipSize` | Размер тултипа: `SM` или `LG` |
+| `children` | `React.ReactNode` | Контент тела подсказки |
+
+### Опциональные props
+
+| Prop | Тип | По умолчанию | Описание |
+|---|---|---|---|
+| `isOpen` | `boolean` | `undefined` | Управляемое состояние открытия тултипа |
+| `toggle` | `(open: boolean) => void` | — | Callback при открытии/закрытии |
+| `onShow` | `(node: HTMLDivElement) => void` | — | Callback при появлении тултипа в DOM |
+| `preferPlace` | `ETooltipPreferPlace` | — | Предпочтительное расположение: `ABOVE`, `BELOW`, `LEFT`, `RIGHT` |
+| `mobileHeaderContent` | `React.ReactNode` | — | Контент заголовка в мобильной версии тултипа |
+| `focusTrapProps` | `FocusTrapProps` | — | Свойства `focus-trap-react` для ловушки фокуса |
+| `tooltipAriaAttributes` | `TAriaHTMLAttributes` | — | Aria-атрибуты, пробрасываемые в Tooltip-контейнер |
+| `tooltipDataAttributes` | `TDataHTMLAttributes` | — | Data-атрибуты, пробрасываемые в Tooltip-контейнер |
+| `iconProps` | `ISingleColorIconProps` | — | Свойства иконки вопроса (например, `paletteIndex`) |
+| `tooltipXButtonProps` | `ITooltipXButtonProps` | — | Свойства кнопки закрытия Tooltip (включая `aria-label`) |
+| `className` | `string` | — | CSS-класс, пробрасывается на кнопку-триггер |
+| `...rest` | `React.HTMLAttributes<HTMLButtonElement>` | — | Все стандартные атрибуты `<button>`, включая `aria-label`, пробрасываются на кнопку-триггер |
+
+### Controlled / Uncontrolled
+
+- **Uncontrolled** (по умолчанию): `isOpen` не передан — компонент сам управляет `openState`.
+- **Controlled**: передай `isOpen` + `toggle` — компонент не меняет внутреннее состояние.
+
+---
+
+## Ключевые особенности реализации
+
+### Композиция внутренних компонентов
+
+HelpBox — обёртка над несколькими внутренними компонентами:
+- `ButtonIcon` (shape=CIRCLE) — кнопка-триггер с иконкой `QuestioncircleFilledSrvIcon16`
+- `Tooltip` (toggleType="hover", role="dialog") — всплывающая подсказка
+- `FocusTrap` (только desktop, через `MobileView`) — ловушка фокуса при открытом тултипе
+- `TooltipMobileHeader` — заголовок мобильной версии (рендерится только при наличии `mobileHeaderContent`)
+
+### FocusTrap
+
+Ловушка фокуса активируется только на desktop (через `MobileView` fallback). При открытии:
+- `initialFocus` — элемент Tooltip (по ID)
+- `clickOutsideDeactivates: true` — клик за пределами закрывает
+- `preventScroll: true`
+
+Потребитель может расширить настройки через `focusTrapProps.focusTrapOptions`.
+
+### Ref forwarding
+
+`forwardRef` пробрасывает ref на внутренний `ButtonIcon` (кнопку-триггер). Внутренний `buttonRef` используется для позиционирования Tooltip через `targetRef`.
+
+---
+
+## Accessibility
+
+- Кнопка-триггер — нативный `<button>` через `ButtonIcon`, shape `CIRCLE`.
+- **`aria-label` триггера** — не захардкожен. Потребитель **обязан** передать `aria-label` через `...rest` (например, `aria-label="Подсказка"`). Библиотека мультиязычная, текст не хардкодится.
+- **`aria-label` кнопки закрытия** — передаётся через `tooltipXButtonProps={{ "aria-label": "Закрыть" }}`. Потребитель **обязан** указать значение на своём языке.
+- Tooltip открывается с `role="dialog"`, `tabIndex={-1}`.
+- FocusTrap удерживает фокус внутри открытого тултипа на desktop.
+- `tooltipAriaAttributes` позволяет добавить aria-атрибуты к контейнеру Tooltip.
+
+---
+
+## Дизайн-токены
+
+Компонент не использует собственных CSS-переменных. Все визуальные стили наследуются от `ButtonIcon` и `Tooltip`.
+
+---
+
+## Инварианты
+
+- **`forwardRef`** — обязателен, не убирать.
+- **`IHelpBoxProps` интерфейс** — экспортируемый, часть публичного API.
+- **`tooltipSize` prop** — обязательный, не делать optional.
+- **Barrel export в `index.ts`** — не удалять.
+- **`toggleType="hover"`** — Tooltip реагирует на наведение, не менять без согласования.
+
+---
+
+## Связанные компоненты
+
+- `Tooltip` (`src/components/Tooltip/`) — всплывающая подсказка, основной визуальный элемент
+- `ButtonIcon` (`src/components/Button/ButtonIcon.tsx`) — кнопка-триггер
+- `MobileView` (`src/components/MobileView/`) — переключение desktop/mobile поведения
+- `FocusTrap` (npm: `focus-trap-react`) — ловушка фокуса для desktop
+
+---
+
+## Stories
+
+`stories/HelpBox/HelpBox.stories.tsx`
+
+| Story | Что демонстрирует |
+|---|---|
+| `Playground` | Интерактивный контроль всех props |
+| `Default` | Минимальное использование |
+| `Sizes` | Размеры тултипа SM / LG |
+| `Placement` | Расположение: above, below, left, right |
+| `WithMobileHeader` | Мобильный заголовок |
+| `Controlled` | Управляемое состояние (isOpen + toggle) |
+| `ChangeIconProps` | Кастомизация иконки через iconProps |
+| `VisualTests` | Скриншот-тест с открытым тултипом |
+
+---
+
+## История изменений
+
+| Дата | Изменение |
+|---|---|
+| 2026-04-08 | Создан документ. Добавлен `forwardRef`. |

--- a/src/components/HelpBox/HelpBox.tsx
+++ b/src/components/HelpBox/HelpBox.tsx
@@ -4,7 +4,7 @@ import { ISingleColorIconProps, QuestioncircleFilledSrvIcon16 } from "@sberbusin
 import { ButtonIcon } from "../Button/ButtonIcon";
 import { EButtonIconShape } from "../Button/enums";
 import { Tooltip } from "../Tooltip/Tooltip";
-import { ITooltipProps } from "../Tooltip/types";
+import { ITooltipProps, ITooltipXButtonProps } from "../Tooltip/types";
 import { ETooltipSize } from "../Tooltip/enums";
 import { TooltipMobileHeader } from "../Tooltip/components/mobile/components/TooltipMobileHeader";
 import { MobileView } from "../MobileView/MobileView";
@@ -15,7 +15,8 @@ import clsx from "clsx";
 
 /** Свойства компонента HelpBox. */
 export interface IHelpBoxProps
-    extends React.HTMLAttributes<HTMLButtonElement>,
+    extends
+        React.HTMLAttributes<HTMLButtonElement>,
         Pick<ITooltipProps, "isOpen" | "preferPlace" | "onShow" | "toggle"> {
     /** Свойства FocusTrap. Используется npm-пакет focus-trap-react. */
     focusTrapProps?: FocusTrapProps;
@@ -29,104 +30,121 @@ export interface IHelpBoxProps
     mobileHeaderContent?: React.ReactNode;
     /** Свойства иконки. */
     iconProps?: ISingleColorIconProps;
+    /** Свойства кнопки закрытия Tooltip. */
+    tooltipXButtonProps?: ITooltipXButtonProps;
 }
 
 /** Иконка "?" со всплывающей подсказкой выбранного размера. */
-export const HelpBox: React.FC<IHelpBoxProps> = ({
-    children,
-    className,
-    focusTrapProps,
-    mobileHeaderContent,
-    isOpen: openProp,
-    onShow,
-    tooltipSize,
-    preferPlace,
-    toggle,
-    tooltipAriaAttributes,
-    tooltipDataAttributes,
-    iconProps,
-    ...targetHtmlAttrs
-}) => {
-    const ref = useRef<HTMLButtonElement>(null);
-    const [openState, setOpenState] = useState(Boolean(openProp));
-    const [focusTrapNode, setFocusTrapNode] = useState<HTMLDivElement | null>(null);
-    const tooltipId = useId();
-    const open = openProp ?? openState;
+export const HelpBox = React.forwardRef<HTMLButtonElement, IHelpBoxProps>(
+    (
+        {
+            children,
+            className,
+            focusTrapProps,
+            mobileHeaderContent,
+            isOpen: openProp,
+            onShow,
+            tooltipSize,
+            preferPlace,
+            toggle,
+            tooltipAriaAttributes,
+            tooltipDataAttributes,
+            iconProps,
+            tooltipXButtonProps,
+            ...targetHtmlAttrs
+        },
+        ref,
+    ) => {
+        const buttonRef = useRef<HTMLButtonElement | null>(null);
+        const [openState, setOpenState] = useState(Boolean(openProp));
+        const [focusTrapNode, setFocusTrapNode] = useState<HTMLDivElement | null>(null);
+        const tooltipId = useId();
+        const open = openProp ?? openState;
 
-    /** Обработчик закрытия/открытия Tooltip. */
-    const handleTooltipToggle = (open: boolean) => {
-        if (openProp === undefined) {
-            setOpenState(open);
-        }
-
-        if (!open) {
-            setFocusTrapNode(null);
-        }
-
-        toggle?.(open);
-    };
-
-    /** Обработчик появления Tooltip. */
-    const handleTooltipShow = (node: HTMLDivElement) => {
-        setFocusTrapNode(node);
-        onShow?.(node);
-    };
-
-    /** Рендер ловушки фокуса. */
-    const renderFocusTrap = (node: HTMLDivElement) => (
-        <MobileView
-            fallback={
-                <FocusTrap
-                    active={open}
-                    {...focusTrapProps}
-                    focusTrapOptions={{
-                        clickOutsideDeactivates: true,
-                        initialFocus: `[id='${tooltipId}']`,
-                        preventScroll: true,
-                        ...focusTrapProps?.focusTrapOptions,
-                    }}
-                    containerElements={[node]}
-                />
+        /** Функция для хранения ссылки. */
+        const setRef = (instance: HTMLButtonElement | null) => {
+            buttonRef.current = instance;
+            if (typeof ref === "function") {
+                ref(instance);
+            } else if (ref) {
+                (ref as React.MutableRefObject<HTMLButtonElement | null>).current = instance;
             }
-        >
-            {null}
-        </MobileView>
-    );
+        };
 
-    return (
-        <>
-            <Tooltip
-                id={tooltipId}
-                tabIndex={-1}
-                role="dialog"
-                toggleType="hover"
-                size={tooltipSize}
-                preferPlace={preferPlace}
-                isOpen={open}
-                toggle={handleTooltipToggle}
-                onShow={handleTooltipShow}
-                targetRef={ref}
-                {...(Boolean(tooltipAriaAttributes) && getAriaHTMLAttributes(tooltipAriaAttributes!))}
-                {...(Boolean(tooltipDataAttributes) && getDataHTMLAttributes(tooltipDataAttributes!))}
+        /** Обработчик закрытия/открытия Tooltip. */
+        const handleTooltipToggle = (open: boolean) => {
+            if (openProp === undefined) {
+                setOpenState(open);
+            }
+
+            if (!open) {
+                setFocusTrapNode(null);
+            }
+
+            toggle?.(open);
+        };
+
+        /** Обработчик появления Tooltip. */
+        const handleTooltipShow = (node: HTMLDivElement) => {
+            setFocusTrapNode(node);
+            onShow?.(node);
+        };
+
+        /** Рендер ловушки фокуса. */
+        const renderFocusTrap = (node: HTMLDivElement) => (
+            <MobileView
+                fallback={
+                    <FocusTrap
+                        active={open}
+                        {...focusTrapProps}
+                        focusTrapOptions={{
+                            clickOutsideDeactivates: true,
+                            initialFocus: `[id='${tooltipId}']`,
+                            preventScroll: true,
+                            ...focusTrapProps?.focusTrapOptions,
+                        }}
+                        containerElements={[node]}
+                    />
+                }
             >
-                <Tooltip.Target>
-                    <ButtonIcon
-                        className={clsx(styles.helpBoxButton, className)}
-                        aria-label="Подсказка"
-                        shape={EButtonIconShape.CIRCLE}
-                        ref={ref}
-                        {...targetHtmlAttrs}
-                    >
-                        <QuestioncircleFilledSrvIcon16 paletteIndex={5} {...iconProps} />
-                    </ButtonIcon>
-                </Tooltip.Target>
-                {mobileHeaderContent && <TooltipMobileHeader>{mobileHeaderContent}</TooltipMobileHeader>}
-                <Tooltip.Body>{children}</Tooltip.Body>
-                <Tooltip.XButton aria-label="Закрыть" />
-            </Tooltip>
-            {open && focusTrapNode && renderFocusTrap(focusTrapNode)}
-        </>
-    );
-};
+                {null}
+            </MobileView>
+        );
+
+        return (
+            <>
+                <Tooltip
+                    id={tooltipId}
+                    tabIndex={-1}
+                    role="dialog"
+                    toggleType="hover"
+                    size={tooltipSize}
+                    preferPlace={preferPlace}
+                    isOpen={open}
+                    toggle={handleTooltipToggle}
+                    onShow={handleTooltipShow}
+                    targetRef={buttonRef}
+                    {...(Boolean(tooltipAriaAttributes) && getAriaHTMLAttributes(tooltipAriaAttributes!))}
+                    {...(Boolean(tooltipDataAttributes) && getDataHTMLAttributes(tooltipDataAttributes!))}
+                >
+                    <Tooltip.Target>
+                        <ButtonIcon
+                            className={clsx(styles.helpBoxButton, className)}
+                            shape={EButtonIconShape.CIRCLE}
+                            ref={setRef}
+                            {...targetHtmlAttrs}
+                        >
+                            <QuestioncircleFilledSrvIcon16 paletteIndex={5} {...iconProps} />
+                        </ButtonIcon>
+                    </Tooltip.Target>
+                    {mobileHeaderContent && <TooltipMobileHeader>{mobileHeaderContent}</TooltipMobileHeader>}
+                    <Tooltip.Body>{children}</Tooltip.Body>
+                    <Tooltip.XButton {...tooltipXButtonProps} />
+                </Tooltip>
+                {open && focusTrapNode && renderFocusTrap(focusTrapNode)}
+            </>
+        );
+    },
+);
 
 HelpBox.displayName = "HelpBox";

--- a/src/components/HelpBox/__tests__/HelpBox.test.tsx
+++ b/src/components/HelpBox/__tests__/HelpBox.test.tsx
@@ -23,9 +23,9 @@ vi.mock("@sberbusiness/icons-next", () => ({
 }));
 
 describe("HelpBox", () => {
-    it("renders target button with aria-label", () => {
+    it("renders target button with aria-label passed via rest props", () => {
         render(
-            <HelpBox tooltipSize={ETooltipSize.LG} preferPlace={ETooltipPreferPlace.BELOW}>
+            <HelpBox tooltipSize={ETooltipSize.LG} preferPlace={ETooltipPreferPlace.BELOW} aria-label="Подсказка">
                 Текст подсказки
             </HelpBox>,
         );
@@ -65,7 +65,12 @@ describe("HelpBox", () => {
     it("calls toggle(false) when close button is pressed in controlled mode", () => {
         const handleToggle = vi.fn();
         render(
-            <HelpBox tooltipSize={ETooltipSize.LG} isOpen toggle={handleToggle}>
+            <HelpBox
+                tooltipSize={ETooltipSize.LG}
+                isOpen
+                toggle={handleToggle}
+                tooltipXButtonProps={{ "aria-label": "Закрыть" }}
+            >
                 Контент
             </HelpBox>,
         );
@@ -73,5 +78,38 @@ describe("HelpBox", () => {
         const close = screen.getByRole("button", { name: "Закрыть" });
         fireEvent.click(close);
         expect(handleToggle).toHaveBeenCalledWith(false);
+    });
+
+    it("passes tooltipXButtonProps to close button", () => {
+        render(
+            <HelpBox tooltipSize={ETooltipSize.LG} isOpen tooltipXButtonProps={{ "aria-label": "Close" }}>
+                Контент
+            </HelpBox>,
+        );
+
+        expect(screen.getByRole("button", { name: "Close" })).toBeInTheDocument();
+    });
+
+    it("forwards ref to button element", () => {
+        const ref = React.createRef<HTMLButtonElement>();
+        render(
+            <HelpBox tooltipSize={ETooltipSize.LG} ref={ref} aria-label="Подсказка">
+                Контент
+            </HelpBox>,
+        );
+
+        expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+        expect(ref.current).toBe(screen.getByRole("button", { name: "Подсказка" }));
+    });
+
+    it("passes className to target button", () => {
+        render(
+            <HelpBox tooltipSize={ETooltipSize.LG} className="custom-class" aria-label="Подсказка">
+                Контент
+            </HelpBox>,
+        );
+
+        const button = screen.getByRole("button", { name: "Подсказка" });
+        expect(button).toHaveClass("custom-class");
     });
 });

--- a/stories/HelpBox/HelpBox.stories.tsx
+++ b/stories/HelpBox/HelpBox.stories.tsx
@@ -111,7 +111,12 @@ export const Playground: StoryObj<IHelpBoxPlaygroundProps> = {
 
         return (
             <div style={{ display: "flex", justifyContent: "center", padding: 50 }}>
-                <HelpBox {...helpBoxProps} mobileHeaderContent={mobileHeaderText || undefined}>
+                <HelpBox
+                    {...helpBoxProps}
+                    mobileHeaderContent={mobileHeaderText || undefined}
+                    aria-label="Подсказка"
+                    tooltipXButtonProps={{ "aria-label": "Закрыть" }}
+                >
                     {contentText || "Текст подсказки"}
                 </HelpBox>
             </div>
@@ -223,6 +228,8 @@ export const VisualTests: StoryObj<typeof HelpBox> = {
                 preferPlace={ETooltipPreferPlace.BELOW}
                 mobileHeaderContent="Заголовок подсказки"
                 isOpen
+                aria-label="Подсказка"
+                tooltipXButtonProps={{ "aria-label": "Закрыть" }}
             >
                 Тултип размера LG с длинным содержимым для демонстрации разницы
             </HelpBox>

--- a/stories/HelpBox/examples/ChangeIconPropsExample.tsx
+++ b/stories/HelpBox/examples/ChangeIconPropsExample.tsx
@@ -3,7 +3,12 @@ import { HelpBox, ETooltipSize } from "@sberbusiness/triplex-next";
 
 export const ChangeIconPropsExample = () => (
     <div style={{ padding: 50 }}>
-        <HelpBox tooltipSize={ETooltipSize.SM} iconProps={{ paletteIndex: 0 }}>
+        <HelpBox
+            tooltipSize={ETooltipSize.SM}
+            iconProps={{ paletteIndex: 0 }}
+            aria-label="Подсказка"
+            tooltipXButtonProps={{ "aria-label": "Закрыть" }}
+        >
             Подсказка по элементу интерфейса
         </HelpBox>
     </div>

--- a/stories/HelpBox/examples/ControlledExample.tsx
+++ b/stories/HelpBox/examples/ControlledExample.tsx
@@ -21,6 +21,8 @@ export const ControlledExample = () => {
                 preferPlace={ETooltipPreferPlace.RIGHT}
                 isOpen={open}
                 toggle={handleToggle}
+                aria-label="Подсказка"
+                tooltipXButtonProps={{ "aria-label": "Закрыть" }}
             >
                 Управляемое состояние тултипа
             </HelpBox>

--- a/stories/HelpBox/examples/DefaultExample.tsx
+++ b/stories/HelpBox/examples/DefaultExample.tsx
@@ -3,6 +3,8 @@ import { HelpBox, ETooltipSize } from "@sberbusiness/triplex-next";
 
 export const DefaultExample = () => (
     <div style={{ padding: 50 }}>
-        <HelpBox tooltipSize={ETooltipSize.SM}>Подсказка по элементу интерфейса</HelpBox>
+        <HelpBox tooltipSize={ETooltipSize.SM} aria-label="Подсказка" tooltipXButtonProps={{ "aria-label": "Закрыть" }}>
+            Подсказка по элементу интерфейса
+        </HelpBox>
     </div>
 );

--- a/stories/HelpBox/examples/PlacementExample.tsx
+++ b/stories/HelpBox/examples/PlacementExample.tsx
@@ -5,25 +5,45 @@ export const PlacementExample = () => (
     <div style={{ padding: 50, display: "grid", gridTemplateColumns: "repeat(2, minmax(120px, 1fr))", gap: 32 }}>
         <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
             <span style={{ width: 150 }}>above</span>
-            <HelpBox tooltipSize={ETooltipSize.SM} preferPlace={ETooltipPreferPlace.ABOVE}>
+            <HelpBox
+                tooltipSize={ETooltipSize.SM}
+                preferPlace={ETooltipPreferPlace.ABOVE}
+                aria-label="Подсказка"
+                tooltipXButtonProps={{ "aria-label": "Закрыть" }}
+            >
                 Подсказка сверху
             </HelpBox>
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
             <span style={{ width: 150 }}>below</span>
-            <HelpBox tooltipSize={ETooltipSize.SM} preferPlace={ETooltipPreferPlace.BELOW}>
+            <HelpBox
+                tooltipSize={ETooltipSize.SM}
+                preferPlace={ETooltipPreferPlace.BELOW}
+                aria-label="Подсказка"
+                tooltipXButtonProps={{ "aria-label": "Закрыть" }}
+            >
                 Подсказка снизу
             </HelpBox>
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
             <span style={{ width: 150 }}>left</span>
-            <HelpBox tooltipSize={ETooltipSize.SM} preferPlace={ETooltipPreferPlace.LEFT}>
+            <HelpBox
+                tooltipSize={ETooltipSize.SM}
+                preferPlace={ETooltipPreferPlace.LEFT}
+                aria-label="Подсказка"
+                tooltipXButtonProps={{ "aria-label": "Закрыть" }}
+            >
                 Подсказка слева
             </HelpBox>
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
             <span style={{ width: 150 }}>right</span>
-            <HelpBox tooltipSize={ETooltipSize.SM} preferPlace={ETooltipPreferPlace.RIGHT}>
+            <HelpBox
+                tooltipSize={ETooltipSize.SM}
+                preferPlace={ETooltipPreferPlace.RIGHT}
+                aria-label="Подсказка"
+                tooltipXButtonProps={{ "aria-label": "Закрыть" }}
+            >
                 Подсказка справа
             </HelpBox>
         </div>

--- a/stories/HelpBox/examples/SizesExample.tsx
+++ b/stories/HelpBox/examples/SizesExample.tsx
@@ -5,13 +5,23 @@ export const SizesExample = () => (
     <div style={{ padding: 50, display: "flex", gap: 100 }}>
         <div>
             <div style={{ marginBottom: "8px", fontSize: "16px", fontWeight: "700" }}>SM</div>
-            <HelpBox tooltipSize={ETooltipSize.SM} preferPlace={ETooltipPreferPlace.ABOVE}>
+            <HelpBox
+                tooltipSize={ETooltipSize.SM}
+                preferPlace={ETooltipPreferPlace.ABOVE}
+                aria-label="Подсказка"
+                tooltipXButtonProps={{ "aria-label": "Закрыть" }}
+            >
                 SM
             </HelpBox>
         </div>
         <div>
             <div style={{ marginBottom: "8px", fontSize: "16px", fontWeight: "700" }}>LG</div>
-            <HelpBox tooltipSize={ETooltipSize.LG} preferPlace={ETooltipPreferPlace.BELOW}>
+            <HelpBox
+                tooltipSize={ETooltipSize.LG}
+                preferPlace={ETooltipPreferPlace.BELOW}
+                aria-label="Подсказка"
+                tooltipXButtonProps={{ "aria-label": "Закрыть" }}
+            >
                 LG
             </HelpBox>
         </div>

--- a/stories/HelpBox/examples/WithMobileHeaderExample.tsx
+++ b/stories/HelpBox/examples/WithMobileHeaderExample.tsx
@@ -3,7 +3,12 @@ import { HelpBox, ETooltipSize } from "@sberbusiness/triplex-next";
 
 export const WithMobileHeaderExample = () => (
     <div style={{ padding: 50 }}>
-        <HelpBox tooltipSize={ETooltipSize.SM} mobileHeaderContent="Заголовок">
+        <HelpBox
+            tooltipSize={ETooltipSize.SM}
+            mobileHeaderContent="Заголовок"
+            aria-label="Подсказка"
+            tooltipXButtonProps={{ "aria-label": "Закрыть" }}
+        >
             Текст подсказки
         </HelpBox>
     </div>

--- a/stories/release-notes/v1/1.24.0.mdx
+++ b/stories/release-notes/v1/1.24.0.mdx
@@ -20,6 +20,12 @@ import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
 
 - Для значений `LEFT`/`RIGHT` из `EDropdownAlignment` внедрено адаптивное позиционирование.
 
+**HelpBox**
+
+- Добавлен `forwardRef` — ref пробрасывается на кнопку-триггер.
+- Добавлено свойство `tooltipXButtonProps` для передачи атрибутов на кнопку закрытия Tooltip.
+- Убраны захардкоженные `aria-label` — потребитель передаёт `aria-label` через rest-props и `tooltipXButtonProps`.
+
 **SelectExtendedField**
 
 - Исправлен баг: `onClose` и `onOpen` больше не вызываются при ре-рендере родительского компонента.


### PR DESCRIPTION
## Summary
- Добавлен `forwardRef` на компонент `HelpBox` — ref пробрасывается на кнопку-триггер (`ButtonIcon`)
- Убраны захардкоженные `aria-label="Подсказка"` и `aria-label="Закрыть"` — потребитель передаёт их снаружи через rest-props и новый prop `tooltipXButtonProps`
- Добавлен prop `tooltipXButtonProps?: ITooltipXButtonProps` для передачи атрибутов на кнопку закрытия Tooltip
- Создан `HelpBox-AI.md` — AI-документация компонента
- Обновлены stories, тесты, release notes и ROADMAP

## Test plan
- [x] `npx tsc --noEmit` — ошибок типов в HelpBox нет
- [x] Unit-тесты проходят (7/7): forwardRef, className, tooltipXButtonProps, aria-label через rest, toggle
- [x] Visual regression — запустить Update Visual Snapshots workflow после мержа

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Новые функции**
  * Компонент HelpBox теперь поддерживает пересылку ref на базовый элемент кнопки.
  * Добавлено свойство `tooltipXButtonProps` для управления свойствами кнопки закрытия подсказки.
  * Aria-labels теперь настраиваются через props вместо жестко закодированных значений.

* **Документация**
  * Добавлена полная документация компонента HelpBox с описанием API и примерами использования.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->