### PR TITLE
TRIPLEX-877 ImageGallery: починить e2e-тесты под карусельную разметку Main

### DIFF
--- a/e2e/tests/imageGallery.spec.ts
+++ b/e2e/tests/imageGallery.spec.ts
@@ -32,13 +32,14 @@ test.describe("ImageGallery", () => {
 
         test("click on next/prev arrows switches the main image", async ({ page }) => {
             const mainImage = page.getByRole("img");
-            // Стрелки prev/next — единственные кнопки внутри контейнера крупной картинки.
-            const arrows = mainImage.locator("xpath=..").locator("button");
+            // Стрелки prev/next — кнопки с aria-label, заданным потребителем (см. story Default).
+            const prevArrow = page.getByRole("button", { name: "Предыдущее изображение" });
+            const nextArrow = page.getByRole("button", { name: "Следующее изображение" });
 
-            await arrows.nth(1).click();
+            await nextArrow.click();
             await expect(mainImage).toHaveAttribute("alt", "Photo 2");
 
-            await arrows.nth(0).click();
+            await prevArrow.click();
             await expect(mainImage).toHaveAttribute("alt", "Photo 1");
         });
     });
@@ -58,16 +59,17 @@ test.describe("ImageGallery", () => {
         });
 
         test("dots row is visible and click on a tick switches the main image", async ({ page }) => {
-            const mainImage = page.getByRole("img");
             // Тики-индикаторы — кнопки с aria-label вида "Photo N" (на мобильном вместо миниатюр).
             const dots = page.getByRole("button", { name: /^Photo \d+$/ });
 
             await expect(dots).toHaveCount(4);
-            await expect(mainImage).toHaveAttribute("alt", "Photo 1");
+            // На мобильном Main — карусельная лента: в DOM окно соседних слайдов (prev/current/next),
+            // поэтому активную картинку определяем по её попаданию во вьюпорт (соседи клипаются .main).
+            await expect(page.getByRole("img", { name: "Photo 1" })).toBeInViewport();
 
             // 9 items, bucketSize=2: тик 2 → index 4 → Photo 5
             await dots.nth(2).click();
-            await expect(mainImage).toHaveAttribute("alt", "Photo 5");
+            await expect(page.getByRole("img", { name: "Photo 5" })).toBeInViewport();
             await expect(dots.nth(2)).toHaveAttribute("aria-current", "true");
         });
     });


### PR DESCRIPTION
## Что

Чинит падающие e2e-тесты `ImageGallery` (`e2e/tests/imageGallery.spec.ts`). Сам компонент работает корректно — селекторы в спеке устарели после рефактора `Main` с карусельным свайпом (`SwipeTrack` / `Slide`).

## Причины падений

- **Desktop «click on next/prev arrows»**: тест искал кнопки-стрелки в родителе `<img>` через `xpath=..`. После рефакторинга картинка обёрнута в `.slide`, а стрелки лежат уровнем выше в `.main` — в родителе картинки кнопок нет → таймаут.
- **Mobile «dots row»**: на мобильном `Main` рендерит ленту `SwipeTrack` с окном соседних слайдов (current + next), поэтому `getByRole("img")` находил 2 картинки → strict mode violation.

## Изменения

- Стрелки prev/next теперь ищутся по `aria-label` (`«Предыдущее изображение»` / `«Следующее изображение»`) — в духе остальных селекторов спеки, переведённых на role/aria.
- Активная картинка на мобильном определяется через `toBeInViewport()` (соседние слайды клипаются `overflow:hidden` у `.main`).

## Проверка

`npx playwright test imageGallery` — 5 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

Нет изменений, видимых для пользователей. В этом выпуске обновлены только внутренние тесты для улучшения надежности проверок функциональности галереи изображений на различных устройствах.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SberBusiness/triplex-next/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->