### PR TITLE
TRIPLEX-890 LightBox | Исправлен цвет фона SideOverlay в темной теме

### DIFF
--- a/src/components/DesignTokens/components/LightBox.ts
+++ b/src/components/DesignTokens/components/LightBox.ts
@@ -1,7 +1,11 @@
 import { TDesignTokenValue, TDesignTokenValues } from "../types/DesignTokenTypes";
 
 // Название токенов компонента LightBox.
-export const designTokensComponentsLightBoxKeys = ["Backdrop_Background", "Content_Background"] as const;
+export const designTokensComponentsLightBoxKeys = [
+    "Backdrop_Background",
+    "Content_Background",
+    "SideOverlay_Background",
+] as const;
 // Тип, содержащий названия токенов компонента LightBox.
 export type TDesignTokensComponentsLightBoxKeys = (typeof designTokensComponentsLightBoxKeys)[number];
 // Тип, содержащий названия токенов компонента LightBox и их значения.
@@ -15,4 +19,5 @@ export type TDesignTokensComponentsLightBox = { LightBox: TDesignTokensComponent
 export const LightBox_Tokens: TDesignTokensComponentsLightBoxValues = {
     Backdrop_Background: [{ ref: "ColorDarkNeutralAlpha.30" }, { ref: "ColorDarkNeutralAlpha.30" }], // var(--triplex-next-LightBox-Backdrop_Background)
     Content_Background: [{ ref: "ColorNeutral.70" }, { ref: "ColorDarkNeutral.0" }], // var(--triplex-next-LightBox-Content_Background)
+    SideOverlay_Background: [{ ref: "ColorNeutral.70" }, { ref: "ColorDarkNeutral.20" }], // var(--triplex-next-LightBox-SideOverlay_Background)
 };

--- a/src/components/LightBox/LightBoxSideOverlay/styles/LightBoxSideOverlay.module.less
+++ b/src/components/LightBox/LightBoxSideOverlay/styles/LightBoxSideOverlay.module.less
@@ -57,7 +57,7 @@
         transition: transform 0.6s;
         border-top-left-radius: @sideOverlayBorderRadius;
         border-top-right-radius: @sideOverlayBorderRadius;
-        background-color: var(--triplex-next-LightBox-Content_Background);
+        background-color: var(--triplex-next-LightBox-SideOverlay_Background);
 
         width: 1100px;
         max-width: calc(100% - 32px);

--- a/stories/release-notes/v1/1.33.0.mdx
+++ b/stories/release-notes/v1/1.33.0.mdx
@@ -15,6 +15,10 @@ import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
 
 - Исправлены горизонтальные отступы у `DropdownDesktopListItem`.
 
+**LightBox**
+
+- Изменен цвет фона `LightBoxSideOverlay` в темной теме.
+
 **ModalWindow**
 
 - Отступ от компонента снизу изменен на 100px.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Боковая панель LightBox теперь использует правильный фон для светлой и тёмной тем, обеспечивая корректную визуальную консистентность.
* **Documentation**
  * Обновлены релиз-ноты: задокументировано изменение цвета фона LightBoxSideOverlay для тёмной темы.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->