### PR TITLE
TRIPLEX-869 Table, List | Локально изменен z-index у LoaderScreen

### DIFF
--- a/src/components/List/List-ai.md
+++ b/src/components/List/List-ai.md
@@ -37,6 +37,7 @@ version: "1.0"
 - **`forwardRef`** — обязателен, target — `HTMLUListElement`. Не убирать.
 - **Корневой элемент `<ul>`** — не менять. Семантика списка важна для accessibility.
 - `loading` — overlay-стратегия (содержимое не размонтируется), не путать с `ListItemLoading` (отдельный элемент-спиннер для пагинации).
+- **`.listLoaderScreen` — `z-index: @z-index-step`**. Понижает z-index относительно глобального `@z-index-loader-screen` у `LoaderScreen`, чтобы спиннер перекрывал только содержимое списка, а не `LightBox` / `ModalWindow`. Не повышать без проверки наложения на модальные слои.
 
 ---
 
@@ -72,3 +73,4 @@ version: "1.0"
 | Дата | Изменение |
 |---|---|
 | 2026-04-29 | Создан документ |
+| 2026-06-17 | `List.module.less`: локальный `z-index: @z-index-step` на `.listLoaderScreen` — исправлено перекрытие `LoaderScreen` поверх `LightBox` / `ModalWindow` |

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -13,7 +13,7 @@ export interface IListProps extends React.HTMLAttributes<HTMLUListElement> {
 export const List = React.forwardRef<HTMLUListElement, IListProps>(({ children, className, loading, ...rest }, ref) => (
     <ul className={clsx(styles.list, className)} {...rest} data-tx={process.env.npm_package_version} ref={ref}>
         {children}
-        {loading ? <LoaderScreen type="middle" /> : null}
+        {loading ? <LoaderScreen type="middle" className={styles.listLoaderScreen} /> : null}
     </ul>
 ));
 

--- a/src/components/List/styles/List.module.less
+++ b/src/components/List/styles/List.module.less
@@ -1,6 +1,12 @@
+@import 'src/styles/style';
+
 .list {
     margin: 0;
     padding: 0;
     list-style: none;
     position: relative;
+
+    .listLoaderScreen {
+        z-index: @z-index-step;
+    }
 }

--- a/src/components/Table/TableBasic/styles/TableBasic.module.less
+++ b/src/components/Table/TableBasic/styles/TableBasic.module.less
@@ -179,6 +179,7 @@
 
         .tableLoaderScreen {
             border-radius: 8px 8px 0 0;
+            z-index: @z-index-step;
         }
     }
 

--- a/stories/release-notes/v1/1.34.0.mdx
+++ b/stories/release-notes/v1/1.34.0.mdx
@@ -12,6 +12,10 @@ import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
 
 - Исправлен баг, при котором сегменты становились неодинаковой ширины из-за разного объема текста.
 
+**TableBasic / List**
+
+- Исправлен баг, при котором в состоянии загрузки `LoaderScreen` перекрывал открытые `LightBox` и `ModalWindow`.
+
 **TabsLine**
 
 - Добавлена зависимость размера `NotificationIcon` от размера компонента.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления ошибок**
  * Исправлено отображение экранов загрузки в компонентах List и Table. Теперь они не перекрывают открытые модальные окна и плавающие панели, обеспечивая нормальное взаимодействие с пользовательским интерфейсом.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->