### PR TITLE
TRIPLEX-921 LightBox: пример TopOverlay в LightBox и SideOverlay (репро позиционирования)

### DIFF
--- a/stories/LightBox/examples/WithTopOverlayExample.tsx
+++ b/stories/LightBox/examples/WithTopOverlayExample.tsx
@@ -19,6 +19,9 @@ import {
     FocusTrapUtils,
     EComponentSize,
     Confirm,
+    EConfirmParentComponent,
+    MobileView,
+    Spoiler,
 } from "@sberbusiness/triplex-next";
 
 const POEM_LINES: string[] = [
@@ -51,11 +54,25 @@ const PoemBlock: React.FC = () => (
     </Island>
 );
 
+// Пример для воспроизведения неверного позиционирования TopOverlay.
+// Сценарий: открыть TopOverlay в LightBox, открыть SideOverlay, открыть TopOverlay
+// в SideOverlay, закрыть SideOverlay, раскрыть спойлер (увеличить высоту контента),
+// проскроллить LightBox вниз и снова открыть TopOverlay LightBox.
 export const WithTopOverlayExample = () => {
     const [isOpen, setIsOpen] = useState(false);
+    // Раскрытие спойлера резко увеличивает высоту контента LightBox, чтобы был скролл.
+    const [spoilerExpanded, setSpoilerExpanded] = useState(false);
+
+    // TopOverlay самого LightBox.
     const [openedTopOverlay, setOpenedTopOverlay] = useState(false);
     const [closeConfirmed, setCloseConfirmed] = useState(false);
 
+    // SideOverlay и его собственный TopOverlay.
+    const [openedSideOverlay, setOpenedSideOverlay] = useState(false);
+    const [openedSideTopOverlay, setOpenedSideTopOverlay] = useState(false);
+    const [sideCloseConfirmed, setSideCloseConfirmed] = useState(false);
+
+    // --- TopOverlay самого LightBox ---
     const handleOpenTopOverlay = () => setOpenedTopOverlay(true);
     const handleCloseTopOverlay = () => {
         if (closeConfirmed) {
@@ -67,7 +84,22 @@ export const WithTopOverlayExample = () => {
     };
 
     const handleOpen = () => setIsOpen(true);
+    // Кнопка "Закрыть" в LightBox открывает TopOverlay.
     const handleClose = () => setOpenedTopOverlay(true);
+
+    // --- SideOverlay и его TopOverlay ---
+    const handleOpenSideOverlay = () => setOpenedSideOverlay(true);
+    const handleOpenSideTopOverlay = () => setOpenedSideTopOverlay(true);
+    const handleCloseSideTopOverlay = () => {
+        if (sideCloseConfirmed) {
+            setOpenedSideOverlay(false);
+            setSideCloseConfirmed(false);
+        } else {
+            setOpenedSideTopOverlay(false);
+        }
+    };
+    // Кнопка "Закрыть" в SideOverlay открывает его TopOverlay.
+    const handleCloseSideOverlay = () => setOpenedSideTopOverlay(true);
 
     const renderLightBoxControls = () => (
         <LightBox.Controls key="controls">
@@ -115,6 +147,112 @@ export const WithTopOverlayExample = () => {
         </LightBox.TopOverlay>
     );
 
+    const renderSideTopOverlay = () => (
+        <LightBox.TopOverlay
+            opened={openedSideTopOverlay}
+            onClose={handleCloseSideTopOverlay}
+            onOpen={handleOpenSideTopOverlay}
+        >
+            <Confirm parentComponent={EConfirmParentComponent.SIDE_OVERLAY_MD}>
+                <Confirm.Content>
+                    <Confirm.Content.Title>Внимание</Confirm.Content.Title>
+                    <Confirm.Content.SubTitle>
+                        Несохранённые данные будут утеряны. Вы уверены, что хотите покинуть форму редактирования?
+                    </Confirm.Content.SubTitle>
+                </Confirm.Content>
+                <Confirm.Controls>
+                    <Button
+                        theme={EButtonTheme.SECONDARY}
+                        size={EComponentSize.MD}
+                        onClick={() => setOpenedSideTopOverlay(false)}
+                    >
+                        Отмена
+                    </Button>
+                    <Button
+                        theme={EButtonTheme.DANGER}
+                        size={EComponentSize.MD}
+                        onClick={() => {
+                            handleCloseSideTopOverlay();
+                            setSideCloseConfirmed(true);
+                        }}
+                    >
+                        Покинуть форму
+                    </Button>
+                </Confirm.Controls>
+                <Confirm.Close
+                    title="Закрыть"
+                    // Закрыть по Esc, если TopOverlay открыт.
+                    clickByEsc={openedSideTopOverlay}
+                    onClick={() => setOpenedSideTopOverlay(false)}
+                />
+            </Confirm>
+        </LightBox.TopOverlay>
+    );
+
+    const renderLightBoxSideOverlay = () => (
+        <LightBox.SideOverlay
+            key="sideOverlayMD"
+            opened={openedSideOverlay}
+            size={EComponentSize.MD}
+            isTopLevelSideOverlayOpened={false}
+            isTopOverlayOpened={openedSideTopOverlay}
+        >
+            <Page>
+                <Page.Header type={EHeaderPageType.FIRST} sticky>
+                    <Page.Header.Title>
+                        <Page.Header.Title.Content>
+                            <MobileView
+                                fallback={
+                                    <Title tag="h1" size={ETitleSize.H1} tabIndex={-1}>
+                                        Боковая панель
+                                    </Title>
+                                }
+                            >
+                                <Title tag="h2" size={ETitleSize.H2}>
+                                    Боковая панель
+                                </Title>
+                            </MobileView>
+                        </Page.Header.Title.Content>
+                        <Page.Header.Title.Controls>
+                            <LightBox.SideOverlay.CloseMobile
+                                data-test-id="lightbox-side-overlay-close"
+                                onClick={handleCloseSideOverlay}
+                            />
+                        </Page.Header.Title.Controls>
+                    </Page.Header.Title>
+                </Page.Header>
+
+                <Page.Body type={EBodyPageType.SECOND}>
+                    {[0, 1, 2].map((index) => (
+                        <React.Fragment key={index}>
+                            <PoemBlock />
+                            {index < 2 && <Gap size={16} />}
+                        </React.Fragment>
+                    ))}
+                </Page.Body>
+
+                <Page.Footer type={EFooterPageType.FIRST} sticky>
+                    <Page.Footer.Description>
+                        <Page.Footer.Description.Content>А. С. Пушкин</Page.Footer.Description.Content>
+                        <Page.Footer.Description.Controls>
+                            <Button theme={EButtonTheme.GENERAL} size={EComponentSize.MD}>
+                                Button text
+                            </Button>
+                        </Page.Footer.Description.Controls>
+                    </Page.Footer.Description>
+                </Page.Footer>
+            </Page>
+
+            <LightBox.SideOverlay.CloseDesktop
+                data-test-id="lightbox-side-overlay-close"
+                clickByEsc={!openedSideTopOverlay}
+                onClick={handleCloseSideOverlay}
+            />
+
+            {renderSideTopOverlay()}
+        </LightBox.SideOverlay>
+    );
+
     return (
         <div>
             <Button theme={EButtonTheme.SECONDARY} size={EComponentSize.MD} onClick={handleOpen}>
@@ -122,7 +260,11 @@ export const WithTopOverlayExample = () => {
             </Button>
 
             {isOpen ? (
-                <LightBox isLoading={false} isSideOverlayOpened={false} isTopOverlayOpened={openedTopOverlay}>
+                <LightBox
+                    isLoading={false}
+                    isSideOverlayOpened={openedSideOverlay}
+                    isTopOverlayOpened={openedTopOverlay}
+                >
                     <LightBox.Content key="content" isLoading={false}>
                         <Page>
                             <Page.Header type={EHeaderPageType.FIRST} sticky>
@@ -144,8 +286,12 @@ export const WithTopOverlayExample = () => {
                                         </Text>
                                     </Page.Header.Title.Content>
                                     <Page.Header.Title.Controls>
-                                        <Button theme={EButtonTheme.GENERAL} size={EComponentSize.MD}>
-                                            Button text
+                                        <Button
+                                            theme={EButtonTheme.GENERAL}
+                                            size={EComponentSize.MD}
+                                            onClick={handleOpenSideOverlay}
+                                        >
+                                            SideOverlay MD
                                         </Button>
                                     </Page.Header.Title.Controls>
                                 </Page.Header.Title>
@@ -158,6 +304,23 @@ export const WithTopOverlayExample = () => {
                                         {index < 2 && <Gap size={16} />}
                                     </React.Fragment>
                                 ))}
+
+                                <Gap size={16} />
+
+                                <Spoiler
+                                    labelExpand="Показать ещё строфы"
+                                    labelCollapse="Скрыть строфы"
+                                    size={EComponentSize.MD}
+                                    expanded={spoilerExpanded}
+                                    toggle={setSpoilerExpanded}
+                                >
+                                    {[3, 4, 5, 6].map((index) => (
+                                        <React.Fragment key={index}>
+                                            <PoemBlock />
+                                            {index < 6 && <Gap size={16} />}
+                                        </React.Fragment>
+                                    ))}
+                                </Spoiler>
                             </Page.Body>
 
                             <Page.Footer type={EFooterPageType.FIRST} sticky>
@@ -179,6 +342,8 @@ export const WithTopOverlayExample = () => {
                     </LightBox.Content>
 
                     {renderLightBoxControls()}
+
+                    {renderLightBoxSideOverlay()}
                 </LightBox>
             ) : null}
         </div>


### PR DESCRIPTION
## ⚠️ Do not merge

Демонстрационный пример (репро-стенд) для передачи стороннему разработчику. **Вливать не нужно.**

## Что сделано
- Стори `WithTopOverlayExample` расширена до комбинированного стенда: LightBox со своим `TopOverlay` + `SideOverlay` со своим `TopOverlay` + `Spoiler` для увеличения высоты контента (скролл).

## Зачем
Воспроизвести репортнутый кейс неверного позиционирования `TopOverlay` после взаимодействия с двумя оверлеями и скролла. На текущем `main` кейс не воспроизводится — пример отдаётся стороннему разработчику, чтобы проверить на нашем Storybook.

## Как проверить (сценарий)
1. Открыть LightBox.
2. Открыть `TopOverlay` в LightBox, закрыть его (Отмена).
3. Открыть `SideOverlay` (кнопка «SideOverlay MD»).
4. Открыть `TopOverlay` в `SideOverlay` (крестик), закрыть `SideOverlay` («Покинуть форму»).
5. Раскрыть спойлер «Показать ещё строфы».
6. Проскроллить контент LightBox вниз.
7. Снова открыть `TopOverlay` в LightBox — проверить позиционирование панели.

🤖 Generated with [Claude Code](https://claude.com/claude-code)