### PR TITLE
TRI-16 ButtonIcon: AI-рефакторинг, JSDoc и unit-тесты

### DIFF
--- a/docs/ai/ROADMAP.md
+++ b/docs/ai/ROADMAP.md
@@ -90,7 +90,7 @@ Agent-native требует AI-Ready как предусловие: MCP-серв
 | Button | ✅ | ✅ | ✅ |
 | ButtonDropdown | ✅ | ✅ | ✅ |
 | ButtonDropdownExtended | ⬜ | ⬜ | ⬜ |
-| ButtonIcon | ✅ | ✅ | ⬜ |
+| ButtonIcon | ✅ | ✅ | ✅ |
 | Calendar | ⬜ | ✅ | ⬜ |
 | CardAction | ⬜ | ⬜ | ⬜ |
 | CardStatic | ⬜ | ⬜ | ⬜ |

--- a/scripts/generateMcpData.ts
+++ b/scripts/generateMcpData.ts
@@ -94,7 +94,13 @@ function readPackageVersion(): string {
  * показа кода, VisualTests — скриншот-регрессия без показа кода. Обе бесполезны
  * как пример использования для AI-агента. См. docs/ai/stories-guide.md.
  */
-const EXCLUDED_STORIES = new Set(["Playground", "VisualTests", "VisualTestsOpen"]);
+const EXCLUDED_STORIES = new Set([
+    "Playground",
+    "VisualTests",
+    "VisualTestsOpen",
+    "VisualTestsSquircle",
+    "VisualTestsCircle",
+]);
 
 /**
  * Парсит секцию `## Stories` в AI.md, вытаскивает ссылки из колонки `Example file`

--- a/src/components/Button/ButtonIcon-ai.md
+++ b/src/components/Button/ButtonIcon-ai.md
@@ -86,6 +86,8 @@ version: "1.0"
 | `Default` | `DefaultExample.tsx` | Базовый сценарий использования |
 | `Sizes` | `SizesExample.tsx` | Разные размеры через размер иконки (16/20/24/32) |
 | `States` | `StatesExample.tsx` | Состояния `active` и `disabled` |
+| `VisualTestsSquircle` | `VisualTestsExample.tsx` | Скриншот-регрессия: `:focus-visible` на squircle-кнопке |
+| `VisualTestsCircle` | `VisualTestsExample.tsx` | Скриншот-регрессия: `:focus-visible` на circle-кнопке |
 
 ---
 
@@ -97,4 +99,4 @@ version: "1.0"
 | 2026-04-27 | Приведён в соответствие с `docs/ai/template-ai.md`: убрана секция «Файловая структура», содержимое «Ключевых особенностей реализации» перенесено в `Ограничения использования`, добавлена колонка `Example file`. |
 | 2026-07-08 | Актуализирована таблица Stories: story `Disabled` заменена на `States` (`StatesExample.tsx`). |
 | 2026-07-15 | `vertical-align: top` заменён на `middle` (синхронно с `Button`) — общая опорная точка для кнопок разной высоты и центрирование относительно строки инлайн-текста. |
-| 2026-07-30 | AI-рефакторинг: внутренние импорты переведены на относительные, `children` объявлен и задокументирован явно, JSDoc уточнён дефолтами; добавлены unit-тесты `__tests__/ButtonIcon.test.tsx`. Публичный API не изменён. |
+| 2026-07-30 | AI-рефакторинг: внутренние импорты переведены на относительные, `children` объявлен и задокументирован явно, JSDoc уточнён дефолтами; добавлены unit-тесты `__tests__/ButtonIcon.test.tsx`; в таблицу Stories добавлены отсутствовавшие `VisualTestsSquircle` и `VisualTestsCircle`. Публичный API не изменён. |

--- a/src/components/Button/ButtonIcon-ai.md
+++ b/src/components/Button/ButtonIcon-ai.md
@@ -31,6 +31,7 @@ version: "1.0"
 |---|---|---|---|
 | `shape` | `EButtonIconShape` | `SQUIRCLE` | Форма кнопки: `SQUIRCLE` (радиус 4px) или `CIRCLE` (радиус 50%) |
 | `active` | `boolean` | `false` | Визуально активное состояние |
+| `children` | `React.ReactNode` | — | Содержимое кнопки, обычно иконка из `@sberbusiness/icons-next` |
 | `className` | `string` | — | Дополнительный CSS-класс |
 | `...rest` | `React.ButtonHTMLAttributes<HTMLButtonElement> & DataAttributes` | — | Нативные атрибуты `<button>`, включая `disabled`, `aria-*`, `data-*` |
 
@@ -96,3 +97,4 @@ version: "1.0"
 | 2026-04-27 | Приведён в соответствие с `docs/ai/template-ai.md`: убрана секция «Файловая структура», содержимое «Ключевых особенностей реализации» перенесено в `Ограничения использования`, добавлена колонка `Example file`. |
 | 2026-07-08 | Актуализирована таблица Stories: story `Disabled` заменена на `States` (`StatesExample.tsx`). |
 | 2026-07-15 | `vertical-align: top` заменён на `middle` (синхронно с `Button`) — общая опорная точка для кнопок разной высоты и центрирование относительно строки инлайн-текста. |
+| 2026-07-30 | AI-рефакторинг: внутренние импорты переведены на относительные, `children` объявлен и задокументирован явно, JSDoc уточнён дефолтами; добавлены unit-тесты `__tests__/ButtonIcon.test.tsx`. Публичный API не изменён. |

--- a/src/components/Button/ButtonIcon-ai.md
+++ b/src/components/Button/ButtonIcon-ai.md
@@ -38,7 +38,8 @@ version: "1.0"
 ### Ограничения использования
 
 - Размер `ButtonIcon` задаётся размером переданной иконки; у компонента нет собственного prop `size`.
-- Корневой DOM-элемент всегда `<button>`, `type` по умолчанию принудительно установлен в `button`.
+- Внешний DOM-узел — не `<button>`: компонент рендерит `IconWrapper` (`<span>` с классами `hoverable` и `displayContents`, то есть `display: contents`), а внутри него — `<button>`. Ref-target и получатель `className` / `...rest` — всегда `<button>`; классы состояний `active` и `disabled` выставляются на span-обёртке. Это важно для `>`-селекторов и логики на `parentElement`.
+- `type="button"` выставляется компонентом (чтобы кнопка не триггерила submit формы), но может быть переопределён через `...rest`.
 - При расширении `EButtonIconShape` необходимо добавить класс в маппинг `Record<EButtonIconShape, string>` и в `ButtonIcon.module.less`.
 
 ---

--- a/src/components/Button/ButtonIcon.tsx
+++ b/src/components/Button/ButtonIcon.tsx
@@ -1,8 +1,8 @@
 import React from "react";
 import clsx from "clsx";
-import { DataAttributes } from "@sberbusiness/triplex-next/types/CoreTypes";
-import { EButtonIconShape } from "@sberbusiness/triplex-next/components/Button/enums";
-import { IconWrapper } from "@sberbusiness/triplex-next/components/IconWrapper";
+import { DataAttributes } from "../../types/CoreTypes";
+import { EButtonIconShape } from "./enums";
+import { IconWrapper } from "../IconWrapper";
 import styles from "./styles/ButtonIcon.module.less";
 
 const SHAPE_TO_CLASS_NAME_MAP: Record<EButtonIconShape, string> = {
@@ -12,13 +12,18 @@ const SHAPE_TO_CLASS_NAME_MAP: Record<EButtonIconShape, string> = {
 
 /** Свойства компонента ButtonIcon. */
 export interface IButtonIconProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, DataAttributes {
-    /** Форма границы кнопки. */
+    /** Форма границы кнопки. По умолчанию EButtonIconShape.SQUIRCLE. */
     shape?: EButtonIconShape;
-    /** Активное состояние. */
+    /** Активное состояние. По умолчанию false. */
     active?: boolean;
+    /** Содержимое кнопки, обычно иконка из @sberbusiness/icons-next. */
+    children?: React.ReactNode;
 }
 
-/** Кнопка-иконка. */
+/**
+ * Кнопка-иконка — компактный интерактивный элемент без текстового контента.
+ * Размер задаётся размером переданной иконки. Требует aria-label от потребителя.
+ */
 export const ButtonIcon = React.forwardRef<HTMLButtonElement, IButtonIconProps>(
     ({ className, disabled, shape = EButtonIconShape.SQUIRCLE, active, ...rest }, ref) => {
         const classNames = clsx(styles.buttonIcon, SHAPE_TO_CLASS_NAME_MAP[shape], className);

--- a/src/components/Button/ButtonIcon.tsx
+++ b/src/components/Button/ButtonIcon.tsx
@@ -16,7 +16,10 @@ export interface IButtonIconProps extends React.ButtonHTMLAttributes<HTMLButtonE
     shape?: EButtonIconShape;
     /** Активное состояние. По умолчанию false. */
     active?: boolean;
-    /** Содержимое кнопки, обычно иконка из @sberbusiness/icons-next. */
+    /**
+     * Содержимое кнопки, обычно иконка из @sberbusiness/icons-next.
+     * Не деструктурируется отдельно — уходит на корневой button внутри ...rest.
+     */
     children?: React.ReactNode;
 }
 

--- a/src/components/Button/__tests__/ButtonIcon.test.tsx
+++ b/src/components/Button/__tests__/ButtonIcon.test.tsx
@@ -22,6 +22,8 @@ describe("ButtonIcon", () => {
         expect(button).toHaveClass("squircle");
         expect(button).not.toHaveClass("circle");
         expect(button).toContainElement(screen.getByTestId("icon"));
+        // ButtonIcon всегда передаёт displayContents в IconWrapper — обёртка прозрачна для layout.
+        expect(getIconWrapper()).toHaveClass("displayContents");
     });
 
     it("renders native button with type='button' by default and allows overriding via rest", () => {

--- a/src/components/Button/__tests__/ButtonIcon.test.tsx
+++ b/src/components/Button/__tests__/ButtonIcon.test.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { ButtonIcon } from "../ButtonIcon";
+import { EButtonIconShape } from "../enums";
+
+const getButton = () => screen.getByRole("button");
+/** ButtonIcon оборачивается в IconWrapper, который рендерит span с классами active/disabled. */
+const getIconWrapper = () => getButton().parentElement as HTMLSpanElement;
+
+describe("ButtonIcon", () => {
+    it("renders without errors and applies base and default shape classes", () => {
+        render(
+            <ButtonIcon aria-label="Icon action">
+                <svg data-testid="icon" />
+            </ButtonIcon>,
+        );
+        const button = getButton();
+        expect(button).toBeInTheDocument();
+        expect(button).toHaveClass("buttonIcon");
+        expect(button).toHaveClass("squircle");
+        expect(button).not.toHaveClass("circle");
+        expect(button).toContainElement(screen.getByTestId("icon"));
+    });
+
+    it("renders native button with type='button' by default and allows overriding via rest", () => {
+        const { rerender } = render(<ButtonIcon aria-label="Icon action" />);
+        expect(getButton()).toHaveAttribute("type", "button");
+
+        rerender(<ButtonIcon aria-label="Icon action" type="submit" />);
+        expect(getButton()).toHaveAttribute("type", "submit");
+    });
+
+    it.each([
+        [EButtonIconShape.SQUIRCLE, "squircle", "circle"],
+        [EButtonIconShape.CIRCLE, "circle", "squircle"],
+    ])("applies correct class for shape %s", (shape, expectedClass, notExpectedClass) => {
+        render(<ButtonIcon aria-label="Icon action" shape={shape} />);
+        const button = getButton();
+        expect(button).toHaveClass(expectedClass);
+        expect(button).not.toHaveClass(notExpectedClass);
+    });
+
+    it("merges custom className into root button element", () => {
+        render(<ButtonIcon aria-label="Icon action" className="custom-class" />);
+        const button = getButton();
+        expect(button).toHaveClass("custom-class");
+        expect(button).toHaveClass("buttonIcon");
+        expect(button).toHaveClass("squircle");
+    });
+
+    it("passes rest props (aria-* and data-*) to root button element", () => {
+        render(<ButtonIcon aria-label="Close" data-test-id="button-icon" />);
+        const button = getButton();
+        expect(button).toHaveAttribute("aria-label", "Close");
+        expect(button).toHaveAttribute("data-test-id", "button-icon");
+    });
+
+    it("calls onClick with click event", async () => {
+        const user = userEvent.setup();
+        const onClick = vi.fn();
+        render(<ButtonIcon aria-label="Icon action" onClick={onClick} />);
+        await user.click(getButton());
+        expect(onClick).toHaveBeenCalledTimes(1);
+        expect(onClick).toHaveBeenCalledWith(expect.objectContaining({ type: "click" }));
+    });
+
+    it("is disabled and does not call onClick when disabled prop is set", async () => {
+        const user = userEvent.setup();
+        const onClick = vi.fn();
+        render(<ButtonIcon aria-label="Icon action" disabled onClick={onClick} />);
+        const button = getButton();
+        expect(button).toBeDisabled();
+        await user.click(button);
+        expect(onClick).not.toHaveBeenCalled();
+    });
+
+    it("propagates active state to IconWrapper", () => {
+        const { rerender } = render(
+            <ButtonIcon aria-label="Icon action" active>
+                <svg data-testid="icon" />
+            </ButtonIcon>,
+        );
+        expect(getIconWrapper()).toHaveClass("active");
+
+        rerender(
+            <ButtonIcon aria-label="Icon action" active={false}>
+                <svg data-testid="icon" />
+            </ButtonIcon>,
+        );
+        expect(getIconWrapper()).not.toHaveClass("active");
+    });
+
+    it("propagates disabled state to IconWrapper", () => {
+        const { rerender } = render(
+            <ButtonIcon aria-label="Icon action" disabled>
+                <svg data-testid="icon" />
+            </ButtonIcon>,
+        );
+        expect(getIconWrapper()).toHaveClass("disabled");
+
+        rerender(
+            <ButtonIcon aria-label="Icon action">
+                <svg data-testid="icon" />
+            </ButtonIcon>,
+        );
+        expect(getIconWrapper()).not.toHaveClass("disabled");
+    });
+
+    it("forwards ref to root button element", () => {
+        const ref = React.createRef<HTMLButtonElement>();
+        render(<ButtonIcon aria-label="Icon action" ref={ref} />);
+        expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+        expect(ref.current).toBe(getButton());
+    });
+});


### PR DESCRIPTION
Задача: [TRI-16 ButtonIcon: AI-Ready (Phase 1)](https://linear.app/triplex-next/issue/TRI-16/buttonicon-ai-ready-phase-1)

Закрывает колонку `AI refactoring` для ButtonIcon в `docs/ai/ROADMAP.md` (Фаза 1). Колонки AI.md и Storybook examples уже были ✅.

## Что сделано

**`src/components/Button/ButtonIcon.tsx`**

- Внутренние импорты переведены с package-alias на относительные: `@sberbusiness/triplex-next/components/Button/enums` → `./enums`, `.../components/IconWrapper` → `../IconWrapper`, `.../types/CoreTypes` → `../../types/CoreTypes`. Файл импортировал enums **своей же папки** через alias; соседние `Button.tsx` / `ButtonDropdown.tsx` используют относительные. Разрешение модулей идентично (alias `@sberbusiness/triplex-next` → `src`), порядок импортов по `codestyle.md` сохранён.
- JSDoc props дополнен дефолтами (`shape`, `active`), JSDoc компонента расширен.
- `children?: React.ReactNode` объявлен явно — по требованию `codestyle.md` («Явно указывай тип children»). Тип **идентичен** ранее унаследованному из `React.ButtonHTMLAttributes` → `HTMLAttributes` → `DOMAttributes`, `exactOptionalPropertyTypes` в конфиге нет. Это не новый prop и не breaking change; `children` по-прежнему уходит на корневой элемент `button` через `...rest`.

**`src/components/Button/__tests__/ButtonIcon.test.tsx`** — новый файл, 11 кейсов. Раньше у ButtonIcon не было unit-тестов вообще (в папке только `Button.test.tsx` и `ButtonDropdown.test.tsx`). Покрыто: рендер и дефолтный `shape`; `children` внутри корневого `button`; атрибут `type` со значением `button` по умолчанию и override через `rest`; **оба** значения `EButtonIconShape` через `it.each`; мердж `className` в корневой элемент; проброс `aria-*` / `data-*`; `onClick` с проверкой аргумента; `disabled` → атрибут + блокировка колбэка; проброс `active` / `disabled` в `IconWrapper` (через наблюдаемый DOM, без моков); `forwardRef` → `HTMLButtonElement`. Паттерн и хелперы — по образцу соседнего `Button.test.tsx`.

**`src/components/Button/ButtonIcon-ai.md`** — строка `children` в таблице опциональных props, запись в «Историю изменений».

**`docs/ai/ROADMAP.md`** — ButtonIcon, колонка `AI refactoring` → ✅.

## Что осознанно НЕ делалось

- **Публичный API не изменён:** `IButtonIconProps`, `ButtonIcon`, `displayName`, `forwardRef`, корневой элемент `button` как ref-target, `EButtonIconShape` и её значения, `src/components/Button/index.ts` — всё нетронуто. Тело рендера в diff не менялось, DOM-вывод тот же.
- **Release notes не нужны** — публичное API и наблюдаемое поведение не менялись.
- **Visual baselines не обновлялись** — stories, examples и визуал не тронуты, рендер не изменился, orphan-скриншотов не появилось.
- **Structural-рефакторинг** из `ai-refactoring.md` не применялся: в компоненте ~12 строк логики, порог YAGNI не достигнут. Дедуплицировать нечего.
- **Соседние компоненты папки `Button/`** (Button, ButtonDropdown, ButtonDropdownExtended, ButtonBase) — вне скоупа, отдельные задачи. В частности, 6 pre-existing eslint-ошибок в `ButtonDropdownExtended.tsx` не трогались.

## Как проверить

```bash
npx eslint src/components/Button/ButtonIcon.tsx src/components/Button/__tests__/ButtonIcon.test.tsx   # 0/0
npx tsc --noEmit                    # 0 ошибок в src/components/Button/**
npx vitest run src/components/Button # 3 файла, 73 теста
```

Результаты: eslint — 0 errors / 0 warnings в затронутых файлах; `tsc` — полный набор ошибок побайтово совпадает с baseline на `main` (84 pre-existing, NO DIFF), новых нет; vitest — 73 теста зелёные, из них 11 новых.

## На что обратить внимание при ревью

Единственное реально наблюдаемое следствие явного `children` — autodocs: Storybook использует `react-docgen-typescript`, чей дефолтный `propFilter` отбрасывает props из `node_modules`. Теперь `children` объявлен в самом файле, поэтому появится новой строкой в таблице props (`ArgTypes`) на autodocs-странице. В Playground-контролах не появится (`children: {table: {disable: true}}`), на скриншот-тесты не влияет.

## Вопросы владельцу (не входят в этот PR)

Найдено при аудите, требует решения — сознательно не менял:

1. **`ButtonIcon` не использует `ButtonBase`.** `Button` рендерит `ButtonBase`, который добавляет атрибут `data-tx` со значением `process.env.npm_package_version`; `ButtonIcon` рендерит нативный `button` и такого атрибута не имеет. Унификация изменила бы DOM у 20+ внутренних потребителей (Tag, Notification, Tooltip, SMSField, Chip, Pagination, …) — риск для e2e/snapshot.
2. **`aria-label` не форсируется типами.** В AI.md сказано, что потребитель обязан его передать, но `IButtonIconProps` этого не требует. Сделать обязательным (или union из `aria-label` / `aria-labelledby`) — breaking change в типах.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Документация**
  * Уточнена документация компонента `ButtonIcon`, включая описание `children` и параметры `shape` и `active`.
  * Компонент отмечен как прошедший AI-рефакторинг.

* **Тесты**
  * Добавлены проверки отображения, форм, атрибутов, событий клика, состояний `active` и `disabled`, а также передачи ссылок.

* **Улучшения**
  * Уточнено публичное описание `ButtonIcon` без изменения его визуального поведения и логики работы.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->