### PR TITLE
TRIPLEX-889 LightBox | Исправлен z-index LoaderScreen под TopOverlay

### DIFF
--- a/src/components/LightBox/LightBox-ai.md
+++ b/src/components/LightBox/LightBox-ai.md
@@ -126,6 +126,11 @@ version: "1.0"
   последнего (при переключении роутов второй лайтбокс может смонтироваться раньше, чем
   размонтируется первый). Аналогичный счётчик в `LightBoxViewManager` управляет классами
   mount-ноды (`LightBoxMountNodeViewManager`, `LB-*`).
+- **Локальные z-index внутри лайтбокса** (стековый контекст создаёт `.lightBox`): контролы и
+  sticky-шапка/футер `Page` — 100/101, лоадеры `LightBox.Content` и `LightBox.SideOverlay` — 201,
+  `TopOverlay` — 500. `LoaderScreen` приходит с глобальным `@z-index-loader-screen` (10100), поэтому
+  обе обёртки лоадера обязаны переопределять его локальным значением — иначе лоадер перекрывает
+  `TopOverlay`.
 - Баррел `index.ts` реэкспортирует `LightBox`, `enums`, `LightBoxSideOverlay` — сохранять.
 - React 17 совместимость (синхронизация в release-0): React 18-only API не использовать.
 
@@ -194,3 +199,4 @@ version: "1.0"
 | 2026-07-22 | Создан документ (Phase 1 AI-Ready). В том же изменении — AI-рефакторинг: JSDoc на props, общий `LightBoxArrow` для Prev/Next, хук `useLightBoxSidebarVisibility` для сайдбаров, устранение eslint-подавлений; публичный API не менялся |
 | 2026-07-22 | Добавлен `export` к props-интерфейсам `ILightBoxControlsProps`, `ILightBoxCloseProps`, `ILightBoxPrevProps`, `ILightBoxNextProps`, `ILightBoxSideOverlayLoaderProps` (аддитивно, для консистентности с остальными интерфейсами компонента) |
 | 2026-07-22 | Багфиксы по ревью PR #474: клавиатурные триггеры контролов целятся в видимую кнопку (стрелки не работали на desktop, Esc — на mobile); таймер-хак блокировки скролла заменён счётчиком смонтированных лайтбоксов; `LightBoxViewManager` снимает классы mount-ноды при размонтировании последнего менеджера |
+| 2026-08-17 | Исправлено: `LightBox.TopOverlay` перекрывался лоадером `LightBox.Content`. У `.loadingContentOverlay` теперь локальный z-index (201) — выше sticky-шапки и футера `Page`, но ниже `TopOverlay` (500); раньше `LoaderScreen` шёл с глобальным `@z-index-loader-screen` (10100) |

--- a/src/components/LightBox/styles/LightBox.module.less
+++ b/src/components/LightBox/styles/LightBox.module.less
@@ -69,6 +69,7 @@
     }
 
     .loadingContentOverlay {
+        z-index: @page-header-sticky-z-index + @z-index-step;
         border-top-left-radius: 32px;
         border-top-right-radius: 32px;
         opacity: 0.8;

--- a/stories/release-notes/v1/1.43.0.mdx
+++ b/stories/release-notes/v1/1.43.0.mdx
@@ -10,6 +10,10 @@ import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
 
 - Проведён AI-рефакторинг.
 
+**LightBox**
+
+- Исправлен баг, когда в состоянии `loading` `LightBox.TopOverlay` перекрывался `LoaderScreen`.
+
 **SliderExtended**
 
 - Добавлено: `SliderExtended` и его части (`Dot`, `Mark`, `Marks`, `Rail`, `Track`, `Tooltip`) пробрасывают `ref` на свой корневой элемент — тот же, что получает `className` и `...rest` (у `Tooltip` — обёртка подсказки).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Исправлено отображение слоёв LightBox: экран загрузки больше не перекрывается верхней панелью во время загрузки.
  * Улучшен порядок отображения элементов загрузки и боковой панели.

* **Документация**
  * Обновлены сведения о приоритетах отображения элементов LightBox и исправленном поведении.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->