### PR TITLE
New release 1.43.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@sberbusiness/triplex-next",
-    "version": "1.42.0",
+    "version": "1.43.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@sberbusiness/triplex-next",
-            "version": "1.42.0",
+            "version": "1.43.0",
             "license": "Sber Public License at-nc-sa v.2",
             "dependencies": {
                 "@dnd-kit/core": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@sberbusiness/triplex-next",
-    "version": "1.42.0",
+    "version": "1.43.0",
     "description": "Библиотека компонентов дизайн-системы Triplex.",
     "author": "СберБизнес",
     "license": "Sber Public License at-nc-sa v.2",

--- a/stories/release-notes/v1/1.44.0.mdx
+++ b/stories/release-notes/v1/1.44.0.mdx
@@ -1,0 +1,7 @@
+import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
+
+<Meta title="release-notes/v1/1.44.0" />
+
+<Title>v1.44.0</Title>
+
+<Heading>Изменения</Heading>


### PR DESCRIPTION
Релиз 1.43.0: версия в package.json + заготовка release notes 1.44.0.

Парная 0.43.0 уже опубликована — `dist-tags.latest` сейчас на ней, и вернётся на 1.43.0 после публикации этого релиза. Задача: TRI-118.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Документация**
  * Добавлены примечания к выпуску версии 1.44.0.
* **Обновления**
  * Версия пакета обновлена с 1.42.0 до 1.43.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->