### PR TITLE
TRIPLEX-963 PaginationSelect | Возвращены потерянные свойства

### DIFF
--- a/src/components/Pagination/Pagination-ai.md
+++ b/src/components/Pagination/Pagination-ai.md
@@ -64,6 +64,8 @@ version: "1.0"
 
 Расширяет `ISelectFieldProps` (без `size`, с обязательным `value`) и добавляет `paginationLabel: React.ReactNode` — текст лейбла перед селектом. Размер селекта зафиксирован как `EComponentSize.SM`. `value`, `options`, `onChange` — управляются потребителем.
 
+Распределение свойств по DOM: `className` идёт на корневой `<div>` (он задаёт раскладку лейбла и селекта), все остальные свойства (`data`-атрибуты, `id`, `aria`-атрибуты, `targetProps`, `dropdownProps`, `mobileTitle`, `placeholder` и прочие свойства `SelectField`) прокидываются в `SelectField`. `mobileTitle` по умолчанию равен `paginationLabel`, `targetProps` мержится с внутренним `fieldLabel: ""`, `aria-labelledby` по умолчанию указывает на лейбл, но переопределяется потребителем.
+
 ### Состояние загрузки внутри `MasterTable`
 
 Собственного prop загрузки у пагинации нет. Внутри `MasterTable` с `loading` элементы пагинации
@@ -109,6 +111,7 @@ version: "1.0"
 - Логику `PaginationUtils.createPagesArray` / `generatePageRanges` / `generateRange` не менять без перегенерации `__tests__/paginationUtils.test.tsx` — там зафиксированы граничные случаи раскладки.
 - `PAGINATION_ELLIPSIS_VALUE = -1` — sentinel в массиве страниц, на него завязан рендер многоточия.
 - Блокировка по `MasterTableContext.loading` перекрывает `disabled`, пришедший из props: в состоянии загрузки кнопка заблокирована независимо от того, что передал потребитель. Обратное неверно — вне загрузки решает prop.
+- `PaginationSelect` не должен терять свойства: его публичный тип — свойства `SelectField`, поэтому всё, что не разобрано явно, обязано уходить в `SelectField`. Точечные перечисления props вместо `...rest` здесь уже приводили к молчаливой потере `status`, `targetProps` и `data`-атрибутов.
 - Импорт `MasterTableContext` в частях пагинации — абсолютный (`@sberbusiness/triplex-next/components/Table/MasterTableContext`), как в самом `Table`. Относительный путь сюда не ставить.
 
 ---
@@ -156,5 +159,6 @@ version: "1.0"
 | Дата | Изменение |
 |---|---|
 | 2026-06-22 | Создан документ |
+| 2026-08-26 | `PaginationSelect` прокидывает в `SelectField` все свойства, которые не разбирает сам: `data`-атрибуты, `id`, `aria`-атрибуты, `targetProps`, `dropdownProps`, `mobileTitle` и т.д. Публичный API не изменился. |
 | 2026-08-12 | В состоянии загрузки `MasterTable` элементы пагинации становятся `disabled` — читается из `MasterTableContext.loading`. Публичный API не изменился. Заодно `PaginationSelect` перестал молча терять переданный `status`. |
 | 2026-08-27 | Навигация больше не скрывается при `totalPages <= 1`: отрисовывается одна страница с заблокированными стрелками, высота панели пагинации не схлопывается. Публичный API не изменился. |

--- a/src/components/Pagination/__tests__/Pagination.test.tsx
+++ b/src/components/Pagination/__tests__/Pagination.test.tsx
@@ -222,6 +222,41 @@ describe("PaginationSelect", () => {
         );
         expect(screen.getByText("Items per page")).toBeInTheDocument();
     });
+
+    it("Should forward rest props to SelectField", () => {
+        render(
+            <PaginationSelect
+                paginationLabel="Items per page"
+                onChange={() => {}}
+                options={[]}
+                value={{ id: "0", value: "10", label: "10" }}
+                data-testid="pagination-select"
+                id="page-size"
+            />,
+        );
+
+        const select = screen.getByTestId("pagination-select");
+
+        expect(select).toHaveAttribute("id", "page-size");
+        expect(select).toContainElement(screen.getByRole("combobox"));
+    });
+
+    it("Should keep the label linked with the select when rest props are passed", () => {
+        render(
+            <PaginationSelect
+                paginationLabel="Items per page"
+                onChange={() => {}}
+                options={[]}
+                value={{ id: "0", value: "10", label: "10" }}
+                data-testid="pagination-select"
+            />,
+        );
+
+        const labelId = screen.getByRole("combobox").getAttribute("aria-labelledby");
+
+        expect(labelId).toBeTruthy();
+        expect(document.getElementById(labelId!)).toHaveTextContent("Items per page");
+    });
 });
 
 describe("Pagination inside a loading MasterTable", () => {

--- a/src/components/Pagination/__tests__/Pagination.test.tsx
+++ b/src/components/Pagination/__tests__/Pagination.test.tsx
@@ -295,8 +295,8 @@ describe("PaginationSelect", () => {
         const combobox = screen.getByRole("combobox");
 
         expect(combobox).toHaveClass("custom-target");
-        // Заголовок поля пуст: лейбл рисует сам PaginationSelect.
-        expect(combobox.querySelector("label")).toHaveTextContent("");
+        // Заголовок поля пуст: доступное имя даёт лейбл, который рисует сам PaginationSelect.
+        expect(combobox).toHaveAccessibleName("Items per page");
     });
 
     it("Should let the consumer override the internal fieldLabel", () => {
@@ -310,7 +310,7 @@ describe("PaginationSelect", () => {
             />,
         );
 
-        expect(screen.getByRole("combobox").querySelector("label")).toHaveTextContent("Page size");
+        expect(screen.getByText("Page size")).toBeInTheDocument();
     });
 
     // В мобильном режиме выпадающий список рендерит заголовок mobileTitle. Мобильность определяется

--- a/src/components/Pagination/__tests__/Pagination.test.tsx
+++ b/src/components/Pagination/__tests__/Pagination.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { PaginationNavigation } from "../components/PaginationNavigation";
 import { PaginationNavigationButton } from "../components/PaginationNavigationButton";
 import { PaginationPageButton } from "../components/PaginationPageButton";
@@ -9,6 +9,7 @@ import { PaginationSelect } from "../components/PaginationSelect";
 import { EPaginationNavigationIconDirection } from "../enums";
 import { Pagination } from "../Pagination";
 import { MasterTable } from "../../Table/MasterTable";
+import { EScreenWidth } from "../../../helpers/breakpoints";
 
 describe("Pagination", () => {
     const getPagination = () => screen.getByTestId("pagination");
@@ -210,16 +211,19 @@ describe("PaginationPageEllipsis", () => {
 });
 
 describe("PaginationSelect", () => {
+    const options = [{ id: "0", value: "10", label: "10" }];
+
     it("Should render with label", () => {
         render(
             <PaginationSelect
                 paginationLabel="Items per page"
                 onChange={() => {}}
-                options={[]}
+                options={options}
                 targetProps={{ fieldLabel: "" }}
-                value={{ id: "0", value: "10", label: "10" }}
+                value={options[0]}
             />,
         );
+
         expect(screen.getByText("Items per page")).toBeInTheDocument();
     });
 
@@ -228,9 +232,10 @@ describe("PaginationSelect", () => {
             <PaginationSelect
                 paginationLabel="Items per page"
                 onChange={() => {}}
-                options={[]}
-                value={{ id: "0", value: "10", label: "10" }}
+                options={options}
+                value={options[0]}
                 data-testid="pagination-select"
+                data-test-id="page-size-select"
                 id="page-size"
             />,
         );
@@ -238,6 +243,7 @@ describe("PaginationSelect", () => {
         const select = screen.getByTestId("pagination-select");
 
         expect(select).toHaveAttribute("id", "page-size");
+        expect(select).toHaveAttribute("data-test-id", "page-size-select");
         expect(select).toContainElement(screen.getByRole("combobox"));
     });
 
@@ -246,16 +252,130 @@ describe("PaginationSelect", () => {
             <PaginationSelect
                 paginationLabel="Items per page"
                 onChange={() => {}}
-                options={[]}
-                value={{ id: "0", value: "10", label: "10" }}
+                options={options}
+                value={options[0]}
                 data-testid="pagination-select"
             />,
         );
 
-        const labelId = screen.getByRole("combobox").getAttribute("aria-labelledby");
+        const label = screen.getByText("Items per page");
 
-        expect(labelId).toBeTruthy();
-        expect(document.getElementById(labelId!)).toHaveTextContent("Items per page");
+        expect(label.id).toBeTruthy();
+        expect(screen.getByRole("combobox")).toHaveAttribute("aria-labelledby", label.id);
+    });
+
+    it("Should let the consumer override the generated aria-labelledby", () => {
+        render(
+            <>
+                <span id="custom-label">Page size</span>
+                <PaginationSelect
+                    paginationLabel="Items per page"
+                    onChange={() => {}}
+                    options={options}
+                    value={options[0]}
+                    aria-labelledby="custom-label"
+                />
+            </>,
+        );
+
+        expect(screen.getByRole("combobox")).toHaveAttribute("aria-labelledby", "custom-label");
+    });
+
+    it("Should forward targetProps to the select target", () => {
+        render(
+            <PaginationSelect
+                paginationLabel="Items per page"
+                onChange={() => {}}
+                options={options}
+                value={options[0]}
+                targetProps={{ fieldLabel: "", className: "custom-target" }}
+            />,
+        );
+
+        const combobox = screen.getByRole("combobox");
+
+        expect(combobox).toHaveClass("custom-target");
+        // Заголовок поля пуст: лейбл рисует сам PaginationSelect.
+        expect(combobox.querySelector("label")).toHaveTextContent("");
+    });
+
+    it("Should let the consumer override the internal fieldLabel", () => {
+        render(
+            <PaginationSelect
+                paginationLabel="Items per page"
+                onChange={() => {}}
+                options={options}
+                value={options[0]}
+                targetProps={{ fieldLabel: "Page size" }}
+            />,
+        );
+
+        expect(screen.getByRole("combobox").querySelector("label")).toHaveTextContent("Page size");
+    });
+
+    // В мобильном режиме выпадающий список рендерит заголовок mobileTitle. Мобильность определяется
+    // через window.matchMedia (MobileView → MediaMaxWidth → useMatchMedia), поэтому мокаем matchMedia.
+    describe("mobile view", () => {
+        const originalMatchMedia = window.matchMedia;
+
+        beforeEach(() => {
+            Object.defineProperty(window, "matchMedia", {
+                configurable: true,
+                writable: true,
+                value: (query: string) =>
+                    ({
+                        matches: query === `(max-width: ${EScreenWidth.SM_MAX})`,
+                        media: query,
+                        onchange: null,
+                        addEventListener: () => {},
+                        removeEventListener: () => {},
+                        addListener: () => {},
+                        removeListener: () => {},
+                        dispatchEvent: () => false,
+                    }) as unknown as MediaQueryList,
+            });
+        });
+
+        afterEach(() => {
+            Object.defineProperty(window, "matchMedia", {
+                configurable: true,
+                writable: true,
+                value: originalMatchMedia,
+            });
+        });
+
+        it("Should use paginationLabel as mobileTitle by default", () => {
+            render(
+                <PaginationSelect
+                    paginationLabel="Items per page"
+                    onChange={() => {}}
+                    options={options}
+                    value={options[0]}
+                />,
+            );
+
+            fireEvent.click(screen.getByRole("combobox"));
+
+            // Два вхождения: лейбл рядом с селектом и заголовок мобильного выпадающего списка.
+            expect(screen.getAllByText("Items per page")).toHaveLength(2);
+        });
+
+        it("Should let the consumer override mobileTitle", () => {
+            render(
+                <PaginationSelect
+                    paginationLabel="Items per page"
+                    onChange={() => {}}
+                    options={options}
+                    value={options[0]}
+                    mobileTitle="Page size"
+                />,
+            );
+
+            fireEvent.click(screen.getByRole("combobox"));
+
+            expect(screen.getByText("Page size")).toBeInTheDocument();
+            expect(screen.getAllByText("Items per page")).toHaveLength(1);
+        });
     });
 });
 

--- a/src/components/Pagination/components/PaginationSelect.tsx
+++ b/src/components/Pagination/components/PaginationSelect.tsx
@@ -17,7 +17,20 @@ export interface IPaginationSelectProps
 
 /** Выбор количества элементов на странице. */
 export const PaginationSelect = React.forwardRef<HTMLDivElement, IPaginationSelectProps>(
-    ({ paginationLabel, className, options, value, onChange, status }, ref) => {
+    (
+        {
+            paginationLabel,
+            className,
+            options,
+            value,
+            onChange,
+            status,
+            targetProps,
+            mobileTitle = paginationLabel,
+            ...rest
+        },
+        ref,
+    ) => {
         const [instanceId] = useState(() => `Pagination-${uniqueId()}`);
         const { loading } = useContext(MasterTableContext);
 
@@ -30,14 +43,13 @@ export const PaginationSelect = React.forwardRef<HTMLDivElement, IPaginationSele
                     <SelectField
                         size={EComponentSize.SM}
                         value={value}
-                        mobileTitle={paginationLabel}
+                        mobileTitle={mobileTitle}
                         options={options}
                         onChange={onChange}
                         status={loading ? EFormFieldStatus.DISABLED : status}
-                        targetProps={{
-                            fieldLabel: "",
-                        }}
                         aria-labelledby={instanceId}
+                        {...rest}
+                        targetProps={{ fieldLabel: "", ...targetProps }}
                     />
                 </div>
             </div>

--- a/stories/release-notes/v1/1.44.0.mdx
+++ b/stories/release-notes/v1/1.44.0.mdx
@@ -83,6 +83,7 @@ import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
 **Pagination**
 
 - Добавлено отображение `PaginationNavigation` с заблокированными стрелками в случае, когда страница единственная.
+- Исправлен баг, когда компонент `PaginationSelect` не передавал в `SelectField` `data`-атрибуты, `id`, `aria`-атрибуты и остальные свойства `SelectField` (`targetProps`, `dropdownProps`, `mobileTitle` и другие).
 
 **Tabs**
 

--- a/stories/release-notes/v1/1.44.0.mdx
+++ b/stories/release-notes/v1/1.44.0.mdx
@@ -83,7 +83,6 @@ import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
 **Pagination**
 
 - Добавлено отображение `PaginationNavigation` с заблокированными стрелками в случае, когда страница единственная.
-- Исправлен баг, когда компонент `PaginationSelect` не передавал в `SelectField` `data`-атрибуты, `id`, `aria`-атрибуты и остальные свойства `SelectField` (`targetProps`, `dropdownProps`, `mobileTitle` и другие).
 
 **Tabs**
 

--- a/stories/release-notes/v1/1.45.0.mdx
+++ b/stories/release-notes/v1/1.45.0.mdx
@@ -23,3 +23,7 @@ import { Meta, Title, Heading } from "@storybook/addon-docs/blocks";
 - Добавлено: `MasterTable` пробрасывает `ref` на свой корневой `<div>` — раньше компонент был объявлен как `React.FC`.
 - Добавлено: `ref` пробрасывают и обёртки семейства — `MasterTable.FilterPanel`, `MasterTable.ChipPanel` (и `.Links`), `MasterTable.NoColumns`, `MasterTable.PaginationPanel`, `MasterTable.TableFooter`, `MasterTable.TableBasicSettings`. Раньше все они были объявлены как `React.FC`.
 - Проведён AI-рефакторинг.
+
+**Pagination**
+
+- Исправлен баг, когда компонент `PaginationSelect` не передавал в `SelectField` `data`-атрибуты, `id`, `aria`-атрибуты и остальные свойства `SelectField` (`targetProps`, `dropdownProps`, `mobileTitle` и другие).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления**
  * Исправлена передача дополнительных свойств в селекторе пагинации, включая `data-*`, `id`, ARIA-атрибуты и настройки выпадающего списка.
  * Улучшена доступность: корректно связываются подпись и поле выбора.
  * Уточнено поведение мобильного заголовка и его значения по умолчанию.
  * Исправлено отображение пагинации при отсутствии страниц и при наличии только одной страницы.

* **Документация**
  * Обновлены документация и примечания к выпуску с описанием изменений селектора пагинации.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->