### PR TITLE
TRI-126 Дизайн-токены в mcp-data.json: секция tokens, schemaVersion 2

### DIFF
--- a/docs/ai/ROADMAP.md
+++ b/docs/ai/ROADMAP.md
@@ -227,12 +227,15 @@ Agent-native требует AI-Ready как предусловие: MCP-серв
 - [x] Публикация bundle как GitHub Release asset (`.github/workflows/release.yml`)
 - [x] Beta-публикация npm-пакета `@sberbusiness/triplex-next-mcp-server`
 - [x] Автоматизация обновления bundle на релиз библиотеки (workflow `sync-bundle.yml` в репозитории mcp-server)
+- [x] Дизайн-токены в bundle: секция `tokens` из TS-дерева (`schemaVersion: 2`) — пути
+      `{Группа}.{Токен}`, значения светлой и тёмной темы, ссылки на палитру
 - [ ] Stable-релиз npm-пакета (после стабилизации API tools)
 - [ ] Расширенные tools: `search_components`, `get_props`, `get_invariants`, `get_release_notes`, MCP Prompts/Resources и др. — отслеживается в собственном ROADMAP репозитория mcp-server
 
 **Как это работает:**
 1. На релиз triplex-next workflow генерирует `mcp-data-<версия>.json` (плоский JSON
-   со всеми `*-ai.md`, `docs/ai/*.md`, release notes в поле `raw`) и прикладывает
+   со всеми `*-ai.md`, `docs/ai/*.md`, release notes в поле `raw` и секцией
+   `tokens` с деревом дизайн-токенов) и прикладывает
    к GitHub Release. Только для `1.*`: документация в `0.*` идентична, а два
    одинаковых бандла сделали бы неоднозначным выбор источника.
 2. `fetch-bundle.ts` в mcp-server скачивает asset и раскладывает в дерево

--- a/scripts/__tests__/collectDesignTokens.test.ts
+++ b/scripts/__tests__/collectDesignTokens.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { collectDesignTokens } from "../collectDesignTokens";
+import { DesignTokenUtils } from "../../src/components/DesignTokens/DesignTokenUtils";
+import { DesignTokensCore } from "../../src/components/DesignTokens/DesignTokensCore";
+import { DesignTokensComponents } from "../../src/components/DesignTokens/DesignTokensComponents";
+import { ETriplexNextTheme } from "../../src/components/ThemeProvider/ETriplexNextTheme";
+
+const section = collectDesignTokens("1.44.0");
+
+/**
+ * Разбирает вывод `DesignTokenUtils.getStyle` в карту `Группа.Токен` → значение.
+ * Имя переменной — `--triplex-next-{Группа}-{Токен}-{версия}`; ни группа, ни токен
+ * дефисов не содержат, поэтому первые два сегмента хвоста и есть путь токена.
+ */
+const parseStyle = (theme: ETriplexNextTheme): Map<string, string> => {
+    const map = new Map<string, string>();
+
+    for (const line of DesignTokenUtils.getStyle(theme, {}).split("\n")) {
+        const match = /^--triplex-next-(.+?):\s*(.*);$/.exec(line.trim());
+
+        if (!match) {
+            continue;
+        }
+
+        const [group, token] = match[1].split("-");
+
+        map.set(`${group}.${token}`, match[2]);
+    }
+
+    return map;
+};
+
+describe("collectDesignTokens", () => {
+    it("собирает все группы core- и компонентных токенов", () => {
+        const groups = Object.keys(section.groups);
+
+        expect(groups).toContain("ColorBrand");
+        expect(groups).toContain("Calendar");
+        expect(section.groups.ColorBrand.kind).toBe("core");
+        expect(section.groups.Calendar.kind).toBe("component");
+    });
+
+    it("отмечает refable только у core-групп — ссылки генерируются из DesignTokensCore", () => {
+        const refable = Object.entries(section.groups)
+            .filter(([, group]) => group.refable)
+            .map(([name]) => name)
+            .sort();
+
+        expect(refable).toEqual(Object.keys(DesignTokensCore).sort());
+    });
+
+    it("у каждого токена path совпадает с его местом в дереве", () => {
+        for (const [groupName, group] of Object.entries(section.groups)) {
+            for (const [tokenName, token] of Object.entries(group.tokens)) {
+                expect(token.path).toBe(`${groupName}.${tokenName}`);
+            }
+        }
+    });
+
+    it("сохраняет ref там, где токен ссылается на палитру", () => {
+        expect(section.groups.Calendar.tokens.Background.light.ref).toBe("ColorNeutral.100");
+        expect(section.groups.Calendar.tokens.Background.dark.ref).toBe("ColorDarkNeutral.50");
+        // Токен с собственным значением ссылки не имеет.
+        expect(section.groups.Calendar.tokens.View_Item_Background_Default.light.ref).toBeUndefined();
+    });
+
+    it("resolved совпадает со значением css-переменной светлой темы", () => {
+        const expected = parseStyle(ETriplexNextTheme.LIGHT);
+
+        for (const group of Object.values(section.groups)) {
+            for (const token of Object.values(group.tokens)) {
+                expect(`${token.path}=${token.light.resolved}`).toBe(`${token.path}=${expected.get(token.path)}`);
+            }
+        }
+    });
+
+    it("resolved совпадает со значением css-переменной тёмной темы", () => {
+        const expected = parseStyle(ETriplexNextTheme.DARK);
+
+        for (const group of Object.values(section.groups)) {
+            for (const token of Object.values(group.tokens)) {
+                expect(`${token.path}=${token.dark.resolved}`).toBe(`${token.path}=${expected.get(token.path)}`);
+            }
+        }
+    });
+
+    it("темы расходятся там, где токен объявлен разными значениями", () => {
+        const background = section.groups.Calendar.tokens.Background;
+
+        expect(background.light.resolved).not.toBe(background.dark.resolved);
+    });
+
+    it("покрывает все токены дерева", () => {
+        const collected = Object.values(section.groups).reduce(
+            (sum, group) => sum + Object.keys(group.tokens).length,
+            0,
+        );
+        const expected = [DesignTokensCore, DesignTokensComponents].reduce(
+            (sum, tree) =>
+                sum +
+                Object.values(tree as Record<string, Record<string, unknown>>).reduce(
+                    (groupSum, group) => groupSum + Object.keys(group).length,
+                    0,
+                ),
+            0,
+        );
+
+        expect(collected).toBe(expected);
+    });
+
+    it("описывает внутренний слой отдельным блоком", () => {
+        expect(section.internal.versionSuffix).toBe("1-44-0");
+        expect(section.internal.cssVarPattern).toContain("--triplex-next-");
+    });
+});

--- a/scripts/collectDesignTokens.ts
+++ b/scripts/collectDesignTokens.ts
@@ -1,0 +1,128 @@
+/**
+ * Собирает секцию `tokens` для mcp-data.json — машиночитаемое дерево дизайн-токенов
+ * для `@sberbusiness/triplex-next-mcp-server` (tool `get_tokens`).
+ *
+ * Источник — TS-дерево токенов, а не документация: `DesignTokensCore` (палитра) и
+ * `DesignTokensComponents` (токены компонентов) вместе с их тёмными вариантами.
+ * Значения разрешаются тем же `DesignTokenUtils.getTokenValue`, которым
+ * `ThemeProvider` рендерит css-переменные, поэтому бандл не может разойтись
+ * с тем, что видит потребитель.
+ *
+ * Форма секции:
+ * - группы плоские, как и сам объект токенов (`TDesignTokens`): вложенности
+ *   `core` / `components` в API нет, `kind` несёт ту же информацию для листинга;
+ * - у каждого токена явный `path` — строка, которую потребитель передаёт в
+ *   `ThemeProvider`. Собирать её из ключей вложенности агент не должен;
+ * - `refable` отмечает группы, на которые можно сослаться через `{ ref: "..." }`:
+ *   список ссылок генерируется только из `DesignTokensCore`
+ *   (см. scripts/generateRefTokensTypes.ts);
+ * - `internal` описывает внутренний слой (css-переменные с версией в имени) явно
+ *   отдельным блоком, чтобы его нельзя было принять за публичный API.
+ */
+import { DesignTokensCore } from "../src/components/DesignTokens/DesignTokensCore";
+import { DesignTokensCoreThemeDark } from "../src/components/DesignTokens/DesignTokensCoreThemeDark";
+import { DesignTokensComponents } from "../src/components/DesignTokens/DesignTokensComponents";
+import { DesignTokensComponentsThemeDark } from "../src/components/DesignTokens/DesignTokensComponentsThemeDark";
+import { DesignTokenUtils } from "../src/components/DesignTokens/DesignTokenUtils";
+import type { TDesignTokens } from "../src/components/DesignTokens/types/DesignTokensTypes";
+import type { TDesignTokenValue } from "../src/components/DesignTokens/types/DesignTokenTypes";
+
+/** Значение токена в одной теме. */
+export interface TokenThemeValue {
+    /** Ссылка на core-токен, если значение задано ссылкой. */
+    ref?: string;
+    /** Итоговое css-значение: собственное либо разрешённое по ссылке. */
+    resolved: string;
+}
+
+/** Токен в бандле. */
+export interface TokenEntry {
+    /** Путь `Группа.Токен` — то, что передаётся в ThemeProvider. */
+    path: string;
+    light: TokenThemeValue;
+    dark: TokenThemeValue;
+}
+
+/** Группа токенов в бандле. */
+export interface TokenGroupEntry {
+    /** `core` — палитра и примитивы, `component` — токены компонента. */
+    kind: "core" | "component";
+    /** Можно ли сослаться на токены группы через `{ ref: "Группа.Токен" }`. */
+    refable: boolean;
+    tokens: Record<string, TokenEntry>;
+}
+
+/** Секция `tokens` бандла. */
+export interface TokensSection {
+    /** Подсказка агенту, что означает `path`. */
+    overridePath: string;
+    groups: Record<string, TokenGroupEntry>;
+    internal: {
+        cssVarPattern: string;
+        versionSuffix: string;
+    };
+}
+
+type TokenGroupMap = Record<string, Record<string, TDesignTokenValue>>;
+
+/** Разрешает значение токена в дереве своей темы. */
+const toThemeValue = (token: TDesignTokenValue, tokens: TDesignTokens): TokenThemeValue => {
+    const resolved = DesignTokenUtils.getTokenValue(token, tokens);
+
+    return token.ref === undefined ? { resolved } : { ref: token.ref, resolved };
+};
+
+/**
+ * Собирает секцию `tokens`.
+ * @param version версия пакета — из неё складывается суффикс css-переменных.
+ */
+export const collectDesignTokens = (version: string): TokensSection => {
+    const lightTree = { ...DesignTokensCore, ...DesignTokensComponents } as TDesignTokens;
+    const darkTree = { ...DesignTokensCoreThemeDark, ...DesignTokensComponentsThemeDark } as TDesignTokens;
+    const groups: Record<string, TokenGroupEntry> = {};
+
+    const collect = (
+        light: TokenGroupMap,
+        dark: TokenGroupMap,
+        kind: TokenGroupEntry["kind"],
+        refable: boolean,
+    ): void => {
+        Object.keys(light).forEach((group) => {
+            const tokens: Record<string, TokenEntry> = {};
+
+            Object.keys(light[group]).forEach((name) => {
+                const darkToken = dark[group]?.[name] ?? light[group][name];
+
+                tokens[name] = {
+                    path: `${group}.${name}`,
+                    light: toThemeValue(light[group][name], lightTree),
+                    dark: toThemeValue(darkToken, darkTree),
+                };
+            });
+
+            groups[group] = { kind, refable, tokens };
+        });
+    };
+
+    collect(
+        DesignTokensCore as unknown as TokenGroupMap,
+        DesignTokensCoreThemeDark as unknown as TokenGroupMap,
+        "core",
+        true,
+    );
+    collect(
+        DesignTokensComponents as unknown as TokenGroupMap,
+        DesignTokensComponentsThemeDark as unknown as TokenGroupMap,
+        "component",
+        false,
+    );
+
+    return {
+        overridePath: "Группа.Токен — путь для ThemeProvider prop tokens",
+        groups,
+        internal: {
+            cssVarPattern: "--triplex-next-{Группа}-{Токен}-{версия}",
+            versionSuffix: version.replace(/\./g, "-"),
+        },
+    };
+};

--- a/scripts/generateMcpData.ts
+++ b/scripts/generateMcpData.ts
@@ -21,6 +21,7 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSy
 import { basename, dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 import { glob } from "glob";
+import { collectDesignTokens, type TokensSection } from "./collectDesignTokens";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -55,12 +56,17 @@ interface ReleaseNoteEntry {
 }
 
 interface Bundle {
-    schemaVersion: 1;
+    /**
+     * 2 — добавлена секция `tokens` с деревом дизайн-токенов. Бандлы версии 1
+     * её не содержат, поэтому mcp-server читает секцию опционально.
+     */
+    schemaVersion: 2;
     triplexVersion: string;
     generatedAt: string;
     components: ComponentEntry[];
     guides: GuideEntry[];
     releaseNotes: ReleaseNoteEntry[];
+    tokens: TokensSection;
 }
 
 const GUIDE_TOPICS: { topic: string; file: string }[] = [
@@ -262,12 +268,13 @@ function main(): void {
     const releaseNotes = collectReleaseNotes();
 
     const bundle: Bundle = {
-        schemaVersion: 1,
+        schemaVersion: 2,
         triplexVersion,
         generatedAt: new Date().toISOString(),
         components,
         guides,
         releaseNotes,
+        tokens: collectDesignTokens(triplexVersion),
     };
 
     mkdirSync(dirname(out), { recursive: true });
@@ -276,6 +283,10 @@ function main(): void {
     const aiReady = components.filter((c) => c.raw !== null).length;
     const fallback = components.length - aiReady;
     const totalExamples = components.reduce((sum, c) => sum + c.examples.length, 0);
+    const tokenCount = Object.values(bundle.tokens.groups).reduce(
+        (sum, group) => sum + Object.keys(group.tokens).length,
+        0,
+    );
     process.stdout.write(
         [
             `Wrote ${out}`,
@@ -284,6 +295,7 @@ function main(): void {
             `  examples: ${totalExamples}`,
             `  guides: ${guides.length}`,
             `  releaseNotes: ${releaseNotes.length}`,
+            `  tokens: ${tokenCount} in ${Object.keys(bundle.tokens.groups).length} groups`,
             "",
         ].join("\n"),
     );


### PR DESCRIPTION
## Что сделано

Бандл для `@sberbusiness/triplex-next-mcp-server` не содержал значений токенов:
tool `get_tokens` отдавал только список путей из frontmatter AI.md, а палитра
(`ColorBrand.50` и прочие core-токены) была недоступна вообще. Теперь бандл
несёт всё дерево токенов, собранное из TS-исходников.

- `scripts/collectDesignTokens.ts` — сборка секции: 575 токенов в 66 группах
  (112 core + 463 компонентных). У каждого токена явный `path`, значения светлой
  и тёмной темы и `ref` там, где токен ссылается на палитру.
- Значения разрешаются тем же `DesignTokenUtils.getTokenValue`, которым
  `ThemeProvider` рендерит css-переменные, — бандл не может разойтись с тем,
  что видит потребитель. Тёмная тема резолвится против тёмного дерева.
- Группы плоские, как и сам объект токенов: вложенности `core` / `components`
  в API нет, признак несёт поле `kind`. Явный `path` в каждом токене нужен,
  чтобы агент не собирал путь из ключей вложенности и не изобрёл
  несуществующий `components.Calendar.Background`.
- `refable` отмечает группы, на которые можно сослаться через `{ ref: "..." }`:
  список ссылок генерируется только из `DesignTokensCore`.
- Внутренний слой (css-переменные с версией в имени) описан отдельным блоком
  `internal`, чтобы его нельзя было принять за публичный API.
- `schemaVersion` поднят до 2. Бандлы версии 1 секции не содержат — mcp-server
  читает её опционально, это его часть задачи.

## Как проверить

- `npm run generateMcpData` → `tokens: 575 in 66 groups`
- `npm run test-unit` — 2861 тест, из них 9 новых: два прогоняют все 575 токенов
  против вывода `DesignTokenUtils.getStyle` в светлой и тёмной теме
- `npx tsc --noEmit -p tsconfig.build.json` — чисто

Публичное API библиотеки не меняется, release notes не нужны.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * В MCP bundle добавлена секция дизайн-токенов со значениями для светлой и тёмной тем.
  * Токены теперь включают пути, ссылки на палитры и данные для сопоставления с CSS-переменными.
  * В итоговом bundle отображается статистика по количеству токенов и групп.

* **Документация**
  * Обновлена дорожная карта с описанием поддержки дизайн-токенов и схемы версии 2.

* **Тесты**
  * Добавлены проверки полноты токенов, значений тем, ссылок на палитры и метаданных.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->