### PR TITLE
Guidelines: правила TPX-G-10, 11, 13–20 из вычиток бенчмарка (TRI-130)

### DIFF
--- a/docs/mcp/guidelines.md
+++ b/docs/mcp/guidelines.md
@@ -115,3 +115,143 @@ import "@sberbusiness/icons-next/styles/icons.css";
 Вертикальные отступы между блоками (айлендами, панелями, секциями) задаются
 компонентом `Gap` с размером из шкалы, а не `margin` или пустыми
 контейнерами.
+
+## TPX-G-10 — Конвенция имён слоёв макета
+
+Имена слоёв несут семантику для чтения макета: префикс `_` — служебный
+слой, игнорируется вместе с поддеревом (мишени прототипных переходов,
+черновики); префикс `#` — слот шаблона (контейнер контента); префикс `@` —
+иконка, подменяется иконкой из `@sberbusiness/icons-next`; суффиксы
+`_text`/`_label`/`_placeholder` указывают, какому текстовому prop
+компонента принадлежит текст ноды. Остальные имена — осмысленные; мусорные
+имена (`Frame 427`, `Rectangle 12`) деградируют именной фолбэк маппинга.
+
+## TPX-G-11 — TableBasic: ячейка рендерится только при наличии fieldKey в rowData
+
+Каждая колонка `TableBasic` обязана иметь соответствующий ключ в `rowData`
+КАЖДОЙ строки — ячейку без ключа компонент молча пропускает. Колонкам, чей
+контент даёт `renderCell` (кнопки, статусы, чекбоксы), в `rowData` кладётся
+значение-заглушка. Таким колонкам также обязателен
+`cellType: ECellType.COMPONENTS` (чекбоксам — `CHECKBOX`): при дефолтном
+`TEXT` контент оборачивается в `Text B3`, ломая отступы и семантику.
+
+```tsx
+// колонка: {fieldKey: "sign", cellType: ECellType.COMPONENTS, renderCell: () => <Button …>Подписать</Button>}
+// строка:  rowData: {…, sign: true}  // без ключа sign ячейка не отрендерится
+```
+
+## TPX-G-12 — отменено
+
+Id зарезервирован и отменён до публикации (конвенция оформления импортов —
+стиль потребителя, на кодогенерацию из макета не влияет). Id не
+переиспользуется.
+
+## TPX-G-13 — Вес Typography — из суффикса текст-стиля макета
+
+Суффикс имени текст-стиля макета задаёт начертание: `-M` (`Header/H3-M`) →
+`weight={EFontWeightTitle.MEDIUM}` — дефолт `Title` semibold, без явного
+`weight` текст будет жирнее макета; `-S` (`Header/H1-S`) → semibold,
+`weight` не пишется (дефолт). Аналогично для `Text` (`EFontWeightText`).
+Проверять текст-стиль узла макета, а не полагаться на визуальную оценку.
+
+```tsx
+<Title size={ETitleSize.H3} weight={EFontWeightTitle.MEDIUM}>…</Title> // стиль макета Header/H3-M
+<Title tag="h1" size={ETitleSize.H1}>…</Title> // стиль Header/H1-S: semibold — дефолт
+```
+
+## TPX-G-14 — HelpBox и тултипы — без preferPlace
+
+У `HelpBox` (и тултипов) `preferPlace` как правило не указывается — логики
+компонента хватает, чтобы позиционировать тултип правильно; явный prop
+ничего не ломает, но избыточен. Вариант `Position=Top/Left/…` из макета в
+prop не переносится.
+
+```tsx
+<HelpBox tooltipSize={ETooltipSize.SM}>Текст подсказки</HelpBox>
+// НЕВЕРНО: <HelpBox tooltipSize={ETooltipSize.SM} preferPlace={ETooltipPreferPlace.ABOVE}>…</HelpBox>
+```
+
+## TPX-G-15 — Инлайн-стили в коде на компонентах ДС запрещены
+
+В коде приложений на компонентах Triplex НИКОГДА не писать `style={{…}}`
+для раскладки, отступов и выравнивания — их дают сами компоненты (`Gap`,
+`Row`/`Col`, штатные подкомпоненты). Если базовый компонент не умеет
+раскладку, которую рисует макет (пример: право-выровненный футер есть у
+`IslandWidget`/`IslandAccordion`, у базового `Island` — нет), это ошибка
+макета: контент кладётся в компонент как есть, расхождение фиксируется
+диагностикой. Исключение — фреймы без компонентов ДС (absolute-витрины),
+где штатной раскладки не существует.
+
+```tsx
+// НЕВЕРНО: <Island.Footer style={{display: "flex", justifyContent: "flex-end", gap: 16}}>
+<Island.Footer><Button …>Отмена</Button><Button …>Сохранить</Button></Island.Footer>
+```
+
+## TPX-G-16 — Описание и постфикс полевых компонентов — через targetProps
+
+У полевых компонентов, чей `targetProps` наследует TextFieldBase
+(`DateField` через MaskedField и т.п.), описание под полем и постфикс
+(в т.ч. `HelpBox`) передаются через `targetProps.description` /
+`targetProps.postfix` — постфикс НЕ перетирает встроенные иконки (календарь
+`DateField`). У `SelectField` prop `description` отсутствует — там описание
+строится паттерном `FormGroup` + `SelectField` + `FormFieldDescription`.
+Перед выбором паттерна сверяться с примером `get_component`.
+
+```tsx
+<DateField … targetProps={{postfix: <HelpBox tooltipSize={ETooltipSize.SM} />, description: <Text …>…</Text>}} />
+<FormGroup><SelectField … /><FormFieldDescription>…</FormFieldDescription></FormGroup>
+```
+
+## TPX-G-17 — Композиция MasterTable: ChipPanel и порядок панелей
+
+Чипы-фильтры таблицы кладутся в `MasterTable.ChipPanel` (`ChipGroup`
+size SM `oneLine`), правая часть строки чипов — `MasterTable.ChipPanel.Links`
+(туда же — `TableBasicSettings` со ссылкой настроек), а не в `FilterPanel`.
+Порядок панелей: `ChipPanel` → `TableBasic` → `TableFooter` (появляется при
+выборе строк) → `PaginationPanel`. Варианты чипов макета: `Chip/DatePicker` →
+`ChipDatePicker`, `Chip/Select` → `ChipSelect`, `Chip/Multiselect` →
+`ChipMultiselect`, `Chip/Suggest` → `ChipSuggest`; `Chip/MonthYearPicker`
+аналога не имеет → `ChipSelect`.
+
+## TPX-G-18 — Кнопка-иконка: Button с icon vs ButtonIcon
+
+Варианты кнопок макета `Type=Icon*` (`IconSecondary`, `IconSecondaryLight`,
+…) — это `Button` с prop `icon` и соответствующей темой, БЕЗ children (плюс
+`aria-label`). `ButtonIcon` — только для «голой» иконки-кнопки без подложки.
+В ячейках таблиц и шапках страниц кнопки с серой/светлой подложкой —
+`Button` с `icon`. Размер иконки — из макета (MD-кнопка → 20, LG → 24).
+
+```tsx
+<Button icon={<DefaulticonStrokePrdIcon20 paletteIndex={0} />} theme={EButtonTheme.SECONDARY} size={EComponentSize.MD} aria-label="Действие" />
+```
+
+## TPX-G-19 — columns TableBasic — стабильная ссылка
+
+Массив `columns` для `TableBasic` должен быть стабильным по ссылке между
+рендерами (`useMemo`/константа модуля): `TableBasic` пишет columns в
+`MasterTableContext` через `useEffect` с проверкой `isEqual`, а `isEqual`
+сравнивает функции (`renderCell`) по ссылке — пересоздаваемый каждый рендер
+массив крутит бесконечную петлю записи в контекст. Симптомы: лишние
+ре-рендеры, нестабильный список в `ColumnSettings`.
+
+```tsx
+const columns = useMemo<ITableBasicColumn[]>(() => [...], [/* state, от которого зависят renderCell */]);
+```
+
+## TPX-G-20 — ColumnSettings.SortableList не строит пункты сам
+
+У `ColumnSettings.SortableList` props `columns`/`onColumnsChange` — только
+dnd-обвязка (порядок при перетаскивании); пункты списка рендерит потребитель
+детьми: `ColumnSettings.SortableList.Item` с `id={fieldKey}` и контентом
+(обычно `Checkbox` видимости колонки + label). Без детей меню настроек
+открывается пустым.
+
+```tsx
+<ColumnSettings.SortableList columns={cols} onColumnsChange={setCols}>
+    {cols.map((c) => (
+        <ColumnSettings.SortableList.Item key={c.fieldKey} id={c.fieldKey}>
+            <Checkbox checked={!c.hidden} onChange={…}>{c.label}</Checkbox>
+        </ColumnSettings.SortableList.Item>
+    ))}
+</ColumnSettings.SortableList>
+```

--- a/docs/mcp/guidelines.md
+++ b/docs/mcp/guidelines.md
@@ -148,20 +148,27 @@ Id зарезервирован и отменён до публикации (к�
 
 ## TPX-G-13 — Вес Typography — из суффикса текст-стиля макета
 
-Суффикс имени текст-стиля макета задаёт начертание: `-M` (`Header/H3-M`) →
-`weight={EFontWeightTitle.MEDIUM}` — дефолт `Title` semibold, без явного
-`weight` текст будет жирнее макета; `-S` (`Header/H1-S`) → semibold,
-`weight` не пишется (дефолт). Аналогично для `Text` (`EFontWeightText`).
-Проверять текст-стиль узла макета, а не полагаться на визуальную оценку.
+Суффикс имени текст-стиля макета задаёт начертание. Для `Title`
+(`EFontWeightTitle`: REGULAR / MEDIUM / SEMIBOLD / BOLD, дефолт —
+semibold): `-M` (`Header/H3-M`) → `weight={EFontWeightTitle.MEDIUM}` —
+без явного `weight` текст будет жирнее макета; `-S` (`Header/H1-S`) →
+semibold, `weight` не пишется (дефолт). Для `Text` (`EFontWeightText`)
+доступны только REGULAR (дефолт) и SEMIBOLD — веса MEDIUM у `Text` нет:
+стили с суффиксом полужирного начертания (`-S`/`-Sb`) →
+`weight={EFontWeightText.SEMIBOLD}`, прочие — дефолт REGULAR, `weight`
+не пишется. Проверять текст-стиль узла макета, а не полагаться на
+визуальную оценку.
 
 ```tsx
 <Title size={ETitleSize.H3} weight={EFontWeightTitle.MEDIUM}>…</Title> // стиль макета Header/H3-M
 <Title tag="h1" size={ETitleSize.H1}>…</Title> // стиль Header/H1-S: semibold — дефолт
+<Text size={ETextSize.B3} weight={EFontWeightText.SEMIBOLD}>…</Text> // полужирный Body-стиль
+<Text size={ETextSize.B3}>…</Text> // обычный Body-стиль: REGULAR — дефолт
 ```
 
 ## TPX-G-14 — HelpBox и тултипы — без preferPlace
 
-У `HelpBox` (и тултипов) `preferPlace` как правило не указывается — логики
+У `HelpBox` (и тултипов) `preferPlace`, как правило, не указывается — логики
 компонента хватает, чтобы позиционировать тултип правильно; явный prop
 ничего не ломает, но избыточен. Вариант `Position=Top/Left/…` из макета в
 prop не переносится.
@@ -217,7 +224,9 @@ size SM `oneLine`), правая часть строки чипов — `MasterT
 
 Варианты кнопок макета `Type=Icon*` (`IconSecondary`, `IconSecondaryLight`,
 …) — это `Button` с prop `icon` и соответствующей темой, БЕЗ children (плюс
-`aria-label`). `ButtonIcon` — только для «голой» иконки-кнопки без подложки.
+`aria-label`). `ButtonIcon` — только для «голой» иконки-кнопки без подложки;
+это нативный `<button>` без видимого текста, поэтому `aria-label` для него
+обязателен так же, как для icon-`Button`.
 В ячейках таблиц и шапках страниц кнопки с серой/светлой подложкой —
 `Button` с `icon`. Размер иконки — из макета (MD-кнопка → 20, LG → 24).
 


### PR DESCRIPTION
Задача: [TRI-130](https://linear.app/triplex-next/issue/TRI-130).

Переносит в `docs/mcp/guidelines.md` одиннадцать правил кодогенерации, найденных при написании и вычитке владельцем эталонов TRIPLEX-MCP-BENCH-v1 (`dudim/pixso-to-code-research`, 2026-09-02). Формулировки адаптированы под аудиторию файла (потребители ДС), исходники с implementation-паспортами конвертера — в локальном реестре `bench/tools/guidelines.json` исследования.

## Состав

- **TPX-G-10** — конвенция имён слоёв макета
- **TPX-G-11** — TableBasic: fieldKey в rowData + cellType COMPONENTS (ячейка без ключа молча пропускается)
- **TPX-G-12** — секция-заглушка «отменено» по конвенции файла: id отозван до публикации (конвенция импортов — стиль потребителя, на кодогенерацию не влияет)
- **TPX-G-13** — вес Typography из суффикса текст-стиля макета (`-M` → `weight={…MEDIUM}`, `-S` → дефолт)
- **TPX-G-14** — HelpBox и тултипы без `preferPlace`
- **TPX-G-15** — запрет инлайн-стилей в коде на компонентах ДС; невозможная раскладка = ошибка макета
- **TPX-G-16** — описание/постфикс полевых через `targetProps`; у SelectField — FormGroup + FormFieldDescription
- **TPX-G-17** — композиция MasterTable: ChipPanel/ChipPanel.Links, порядок панелей, маппинг Chip-вариантов
- **TPX-G-18** — варианты Type=Icon* — `Button` с `icon`, не ButtonIcon
- **TPX-G-19** — стабильные `columns` TableBasic (`useMemo`; isEqual сравнивает renderCell по ссылке — иначе петля записи в MasterTableContext)
- **TPX-G-20** — пункты `ColumnSettings.SortableList` рендерит потребитель

Правки кода не требуются: `mcp-data.json` генерируется из guidelines.md (`scripts/generateMcpData.ts`), до потребителей доедет с ближайшим релизом и публикацией mcp-сервера.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Документация**
  * Уточнены правила типографики: перечислены доступные начертания для `Title` и `Text`, включая отсутствие `MEDIUM` у `Text`.
  * Добавлены примеры использования обычного и полужирного текста.
  * Исправлена пунктуация в правиле TPX-G-14.
  * Уточнено требование к обязательному доступному имени `aria-label` для `ButtonIcon`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->