### PR TITLE
ROADMAP: строки для семейства Chip (TRI-131…TRI-136)

### DIFF
--- a/docs/ai/ROADMAP.md
+++ b/docs/ai/ROADMAP.md
@@ -101,7 +101,13 @@ Agent-native требует AI-Ready как предусловие: MCP-серв
 | CheckboxXGroup | ✅ | ✅ | ✅ |
 | CheckboxYGroup | ✅ | ✅ | ✅ |
 | Chip | ✅ | ✅ | ✅ |
+| ChipDatePicker | ⬜ | ✅ | ⬜ |
 | ChipGroup | ✅ | ✅ | ✅ |
+| ChipMultiselect | ⬜ | ✅ | ⬜ |
+| ChipOptions | ⬜ | ✅ | ⬜ |
+| ChipSelect | ⬜ | ✅ | ⬜ |
+| ChipSort | ⬜ | ✅ | ⬜ |
+| ChipSuggest | ⬜ | ✅ | ⬜ |
 | Col | ✅ | ✅ | ✅ |
 | CollapsibleTree | ✅ | ✅ | ✅ |
 | CollapsibleTreeExtended | ✅ | ✅ | ✅ |


### PR DESCRIPTION
## Что сделано

В таблицу покрытия Фазы 1 в `docs/ai/ROADMAP.md` добавлены шесть строк семейства Chip, у которых до сих пор не было ни строки в ROADMAP, ни задачи в Linear:

| Компонент | AI.md | Storybook examples | AI refactoring | Задача |
|---|---|---|---|---|
| ChipSelect | ⬜ | ✅ | ⬜ | TRI-131 |
| ChipSort | ⬜ | ✅ | ⬜ | TRI-132 |
| ChipOptions | ⬜ | ✅ | ⬜ | TRI-133 |
| ChipSuggest | ⬜ | ✅ | ⬜ | TRI-134 |
| ChipMultiselect | ⬜ | ✅ | ⬜ | TRI-135 |
| ChipDatePicker | ⬜ | ✅ | ⬜ | TRI-136 |

Отбор по правилу `docs/ai/CONTEXT.md` § «Когда создавать AI.md»: barrel-экспорт + нетривиальный API. Target-компоненты (`ChipSelectTarget`, `ChipDatePickerTarget`, `ChipSuggestTarget`) и внутренние части `ChipSuggest` отдельных строк не получают — описываются в AI.md родителя. `ChipIcon`, `ChipClearButton`, `ChipDropdownArrow` остаются тривиальными обёртками в `Chip-ai.md`.

Storybook examples отмечены ✅ сразу: у всех шести уже есть `stories/Chips/examples/{Component}/` с `index.ts` в modern pattern.

## Как проверить

Только документация. Проверить, что таблица в `docs/ai/ROADMAP.md` осталась валидной и строки стоят в алфавитном порядке.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Документация**
  * Обновлена таблица покрытия компонентов в AI-дорожной карте.
  * Добавлены сведения для компонентов `ChipDatePicker`, `ChipMultiselect`, `ChipOptions`, `ChipSelect`, `ChipSort` и `ChipSuggest`.
  * Для каждого компонента указано наличие примеров Storybook, а также отмечено отсутствие документации `AI.md` и AI-рефакторинга.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->