### PR TITLE
TRI-137 Починить unit-тесты после перелития main → release-0

### DIFF
--- a/src/components/MultiselectField/__tests__/MultiselectFieldDropdown.test.tsx
+++ b/src/components/MultiselectField/__tests__/MultiselectFieldDropdown.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { FocusTrapProps } from "focus-trap-react";
 import { MultiselectField } from "../MultiselectField";
 import { MultiselectFieldDropdown } from "../components/MultiselectFieldDropdown";
 import { MultiselectFieldDropdownHeader } from "../components/MultiselectFieldDropdownHeader";
@@ -10,15 +9,29 @@ import { MultiselectFieldDropdownFooter } from "../components/MultiselectFieldDr
 import { MultiselectFieldContext, IMultiselectFieldContext } from "../MultiselectFieldContext";
 import { EComponentSize } from "../../../enums/EComponentSize";
 
+/**
+ * Минимальный контракт FocusTrap, нужный тесту. Тип объявляется локально, а не берётся из
+ * focus-trap-react: в main (v11) он экспортируется как FocusTrapProps, в release-0 (v10) —
+ * как FocusTrap.Props.
+ */
+interface IFocusTrapMockProps {
+    children?: React.ReactNode;
+    focusTrapOptions?: Record<string, unknown>;
+}
+
 // FocusTrap подменяется, чтобы проверить именно то, что вычисляет компонент — focusTrapOptions.
 // Настоящий перехват фокуса — интеграция стороннего пакета, unit-тестами не покрывается.
-vi.mock("focus-trap-react", () => ({
-    FocusTrap: ({ children, focusTrapOptions }: FocusTrapProps) => (
+// Мок отдаёт и named, и default экспорт: в main компонент импортирует { FocusTrap } (v11),
+// в release-0 — default-импортом (v10).
+vi.mock("focus-trap-react", () => {
+    const FocusTrap = ({ children, focusTrapOptions }: IFocusTrapMockProps) => (
         <div data-testid="focus-trap" data-focus-trap-options={JSON.stringify(focusTrapOptions)}>
             {children}
         </div>
-    ),
-}));
+    );
+
+    return { FocusTrap, default: FocusTrap };
+});
 
 /** Опции focus-trap, с которыми отрендерился выпадающий блок. */
 const getFocusTrapOptions = (): Record<string, unknown> =>

--- a/src/components/Suggest/__tests__/useSuggest.test.tsx
+++ b/src/components/Suggest/__tests__/useSuggest.test.tsx
@@ -1,4 +1,5 @@
-import { act, renderHook } from "@testing-library/react";
+import React from "react";
+import { act, render } from "@testing-library/react";
 import { describe, expect, test, vi } from "vitest";
 import { useSuggest } from "../useSuggest";
 import { ISuggestOption } from "../types";
@@ -6,15 +7,36 @@ import { ISuggestOption } from "../types";
 const OPTION_A: ISuggestOption = { id: "a", label: "Первая опция" };
 const OPTION_B: ISuggestOption = { id: "b", label: "Вторая опция" };
 
-const renderUseSuggest = (props: Partial<Parameters<typeof useSuggest>[0]> = {}) =>
-    renderHook((hookProps: Parameters<typeof useSuggest>[0]) => useSuggest(hookProps), {
-        initialProps: {
-            value: undefined,
-            onSelect: vi.fn(),
-            onFilter: vi.fn(),
-            ...props,
-        } as Parameters<typeof useSuggest>[0],
-    });
+type TUseSuggestProps = Parameters<typeof useSuggest>[0];
+
+/**
+ * Рендерит useSuggest внутри компонента-обёртки и отдаёт наружу его последний результат.
+ * Обёртка вместо renderHook: в release-0 (React 17) запинен @testing-library/react 12,
+ * где renderHook ещё не экспортируется.
+ */
+const renderUseSuggest = (props: Partial<TUseSuggestProps> = {}) => {
+    const result = {} as { current: ReturnType<typeof useSuggest> };
+
+    const SuggestReader: React.FC<{ hookProps: TUseSuggestProps }> = ({ hookProps }) => {
+        result.current = useSuggest(hookProps);
+
+        return null;
+    };
+
+    const initialProps = {
+        value: undefined,
+        onSelect: vi.fn(),
+        onFilter: vi.fn(),
+        ...props,
+    } as TUseSuggestProps;
+
+    const { rerender } = render(<SuggestReader hookProps={initialProps} />);
+
+    return {
+        result,
+        rerender: (nextProps: TUseSuggestProps) => rerender(<SuggestReader hookProps={nextProps} />),
+    };
+};
 
 describe("useSuggest", () => {
     test("initializes inputValue from value label", () => {

--- a/src/components/Suggest/__tests__/useSuggest.test.tsx
+++ b/src/components/Suggest/__tests__/useSuggest.test.tsx
@@ -25,10 +25,10 @@ const renderUseSuggest = (props: Partial<TUseSuggestProps> = {}) => {
 
     const initialProps = {
         value: undefined,
-        onSelect: vi.fn(),
-        onFilter: vi.fn(),
+        onSelect: vi.fn<(value: ISuggestOption | undefined) => void>(),
+        onFilter: vi.fn<(value: string) => void>(),
         ...props,
-    } as TUseSuggestProps;
+    } satisfies TUseSuggestProps;
 
     const { rerender } = render(<SuggestReader hookProps={initialProps} />);
 


### PR DESCRIPTION
## Что сделано

После перелития два теста пришли из main в виде, рассчитанном на более новые
зависимости, чем запинены в release-0 (@testing-library/react 12.1.5 вместо
16.3.2, focus-trap-react 10.3.0 вместо 11.0.6). Падало 27 тестов в 2 файлах.

- useSuggest.test.tsx (11 тестов): renderHook появился только в RTL 13.1.
  Заменён на компонент-обёртку через render — как в useMobileView.test.tsx
  (f55d2cb1). Внешний API хелпера ({ result, rerender }) сохранён, тела
  тестов не тронуты.
- MultiselectFieldDropdown.test.tsx (16 тестов): мок focus-trap-react отдавал
  только named-экспорт { FocusTrap } (v11), а компонент в release-0 импортирует
  default (v10). Мок теперь отдаёт оба — как в HelpBox.test.tsx. Тип пропсов
  мока объявлен локально: в v10 он живёт в неймспейсе FocusTrap.Props, из-за
  чего import type { FocusTrapProps } ронял tsc.

Обе правки кросс-branch совместимы: работают и на React 17/RTL 12/focus-trap 10,
и на React 18/RTL 16/focus-trap 11. Поэтому тот же коммит портируется в main —
иначе следующее перелитие вернуло бы падения.

## Как проверить

- npm run test-unit — 271 файл, 3059 тестов зелёные
- npx tsc --noEmit — 0 ошибок в src/

Release notes не нужны: изменения чисто тестовые, публичный API и наблюдаемое
поведение не меняются.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Тесты**
  * Обновлены проверки выпадающего списка множественного выбора для совместимости с несколькими версиями библиотеки управления фокусом.
  * Сохранена проверка параметров управления фокусом для поддерживаемых версий.
  * Тесты подсказок переведены на способ проверки, совместимый с React 17 и используемой библиотекой тестирования.
  * Повышена стабильность проверки обновления свойств и результатов работы подсказок.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->